### PR TITLE
v0.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
             -c Release -r "$RID" --self-contained \
             -p:PublishSingleFile=false \
             -p:IncludeNativeLibrariesForSelfExtract=false \
+            -p:ExternalTranslations=true \
             -p:DebuggerSupport=false \
             -p:EventSourceSupport=false \
             -p:DebugType=none \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Resumen de todos los cambios relevantes del proyecto.
 
+## v0.2.3
+
+- Flexión de género del personaje: el patcher ahora genera condicionales de género nativos del juego, de forma que los diálogos concuerdan con el género del personaje del jugador (Guerrero/Guerrera de la Luz, aventurero/aventurera...).
+- Actualizado el corpus de traducciones embebido (~47.000 líneas nuevas aprobadas):
+  - Misiones de gremio post-Heavensward de TODAS las clases de crafteo y recolección: Alquimista, Minero, Carpintero, Curtidor, Armero, Pescador, Culinario, Botánico y Herrero (~90 hojas).
+  - Historia principal ARR: parches 2.1 a 2.3 (bloques `GaiUse211-216` y lote `msq22`: apertura, Ul'dah y refugiados de Doma).
+  - Lore y progreso: `MJIProgress` (Isla del Vagabundo), `WKSCosmoToolName` y arranque de `WKSMechaEventData` (Cosmic Exploration).
+- Progreso total: 473.962/802.280 líneas (59,1%, antes 53,0%). Crafting/recolección al 74,2%, minijuegos/eventos al 99,8%, lore/diarios y eventos explícitos al 100%.
+- Barrido tipográfico de todo el corpus: guiones de caja (U+2500) sustituidos por rayas (—) según la puntuación española.
+- Ronda de canon ratificada por entrevista: decisiones de terminología y estilo aplicadas de forma coherente a todo el corpus.
+- Correcciones de parcheo (vendor): auto-corrección de etiquetas de campo permutadas en `ExdPatcher` — filas que antes fallaban en silencio (biografías del Bozja Notebook, `Perform`, `Snipe`, `QTE`...) ahora se aplican al 100%.
+- Arreglado falso positivo en la verificación del patcher.
+
 ## v0.2.2
 
 - Actualizado el corpus de traducciones embebido con 8 lotes nuevos (~6.300 filas aprobadas, +16.769 líneas exactas):

--- a/README.md
+++ b/README.md
@@ -24,23 +24,23 @@ traducibles exactas.
 
 | Métrica | Valor | Avance |
 | --- | ---: | --- |
-| Avance total por líneas | 426.936/804.955 (53,0%) | ![53,0%](https://geps.dev/progress/53?barColor=f1c232) |
-| Hojas OK | 1.212/6.956 (17,4%) | ![17,4%](https://geps.dev/progress/17.4?barColor=da3633) |
+| Avance total por líneas | 473.962/802.280 (59,1%) | ![59,1%](https://geps.dev/progress/59.1?barColor=f1c232) |
+| Hojas OK | 2.152/6.956 (30,9%) | ![30,9%](https://geps.dev/progress/30.9?barColor=f0883e) |
 
 | Área | Líneas traducidas | Avance |
 | --- | ---: | --- |
 | UI / menús / sistema visible | 25.749/25.749 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
 | Objetos / economía / tiendas | 176.572/176.572 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| Combate / acciones / duties | 34.912/34.928 (99,9%) | ![99,9%](https://geps.dev/progress/99.9?barColor=2ea043) |
+| Combate / acciones / duties | 34.911/34.927 (99,9%) | ![99,9%](https://geps.dev/progress/99.9?barColor=2ea043) |
 | Mundo / NPCs / localizaciones | 88.327/88.327 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| Crafting / recolección / progreso | 2.156/7.614 (28,3%) | ![28,3%](https://geps.dev/progress/28.3?barColor=f0883e) |
-| Lore / diarios / colecciones | 19.424/20.745 (93,6%) | ![93,6%](https://geps.dev/progress/93.6?barColor=2ea043) |
-| Minijuegos / eventos / perfil | 2.188/7.532 (29,0%) | ![29,0%](https://geps.dev/progress/29?barColor=f0883e) |
-| Guion - quests | 35.161/269.333 (13,1%) | ![13,1%](https://geps.dev/progress/13.1?barColor=da3633) |
+| Crafting / recolección / progreso | 5.463/7.367 (74,2%) | ![74,2%](https://geps.dev/progress/74.2?barColor=f1c232) |
+| Lore / diarios / colecciones | 20.745/20.745 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
+| Minijuegos / eventos / perfil | 7.384/7.400 (99,8%) | ![99,8%](https://geps.dev/progress/99.8?barColor=2ea043) |
+| Guion - quests | 58.710/261.923 (22,4%) | ![22,4%](https://geps.dev/progress/22.4?barColor=f0883e) |
 | Guion - cinemáticas | 1.518/26.426 (5,7%) | ![5,7%](https://geps.dev/progress/5.7?barColor=da3633) |
-| Guion - custom talk/NPC | 6.158/28.374 (21,7%) | ![21,7%](https://geps.dev/progress/21.7?barColor=f0883e) |
-| Guion - eventos explícitos | 1.469/1.492 (98,5%) | ![98,5%](https://geps.dev/progress/98.5?barColor=2ea043) |
-| Otros / revisión | 33.302/117.863 (28,3%) | ![28,3%](https://geps.dev/progress/28.3?barColor=f0883e) |
+| Guion - custom talk/NPC | 12.443/28.367 (43,9%) | ![43,9%](https://geps.dev/progress/43.9?barColor=f0883e) |
+| Guion - eventos explícitos | 1.469/1.469 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
+| Otros / revisión | 40.671/123.008 (33,1%) | ![33,1%](https://geps.dev/progress/33.1?barColor=f0883e) |
 
 ## Descargar
 

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:338fb75079e6165948f521a9e5cf234480783eddc0a8d28d496fcd70b7dd8a8b
-size 12952699
+oid sha256:a6cf245d07f9ab40e929467fff59406cba402ad8467f31dacf9c0e690aaad1db
+size 16381766

--- a/src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj
+++ b/src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj
@@ -7,6 +7,11 @@
     <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Company>JadeArkadian</Company>
+    <Product>FFXIVSpanish Patcher</Product>
+    <Description>Generador del mod de traducción castellana para FINAL FANTASY XIV</Description>
+    <Copyright>Copyright © 2026 JadeArkadian y colaboradores</Copyright>
+    <RepositoryUrl>https://github.com/JadeArkadian/FFXIV-Spanish-Patcher</RepositoryUrl>
     <!-- Windows .exe file icon. -->
     <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
     <!-- Single-file publish tuning: embed symbols (no loose .pdb), compress the bundle, and drop
@@ -22,6 +27,9 @@
     <RepositorySlug Condition="'$(RepositorySlug)' == ''">JadeArkadian/FFXIV-Spanish-Patcher</RepositorySlug>
     <LatestReleaseApiUrl Condition="'$(LatestReleaseApiUrl)' == ''">https://api.github.com/repos/$(RepositorySlug)/releases/latest</LatestReleaseApiUrl>
     <LatestReleasePageUrl Condition="'$(LatestReleasePageUrl)' == ''">https://github.com/$(RepositorySlug)/releases/latest</LatestReleasePageUrl>
+    <!-- Nexus can ship the Brotli blob beside the app so static PE scanners do not treat the
+         high-entropy translation corpus as an executable payload. Other builds keep it embedded. -->
+    <ExternalTranslations Condition="'$(ExternalTranslations)' == ''">false</ExternalTranslations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -49,6 +57,7 @@
     <AssemblyMetadata Include="RepositorySlug" Value="$(RepositorySlug)" />
     <AssemblyMetadata Include="LatestReleaseApiUrl" Value="$(LatestReleaseApiUrl)" />
     <AssemblyMetadata Include="LatestReleasePageUrl" Value="$(LatestReleasePageUrl)" />
+    <AssemblyMetadata Include="ExternalTranslations" Value="$(ExternalTranslations)" />
   </ItemGroup>
 
   <!-- App assets (window/taskbar icon) bundled as Avalonia resources. -->
@@ -58,9 +67,16 @@
 
   <!-- The versioned translation blob is embedded directly into the executable. -->
   <ItemGroup>
-    <EmbeddedResource Include="..\..\data\translations.dat">
+    <EmbeddedResource Include="..\..\data\translations.dat"
+                      Condition="'$(ExternalTranslations)' != 'true'">
       <LogicalName>FFXIVSpanishPatcher.App.translations.dat</LogicalName>
     </EmbeddedResource>
+    <Content Include="..\..\data\translations.dat"
+             Condition="'$(ExternalTranslations)' == 'true'"
+             Link="translations.dat"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest"
+             TargetPath="translations.dat" />
     <EmbeddedResource Include="..\..\data\recommended-game-version.txt">
       <LogicalName>FFXIVSpanishPatcher.App.recommended-game-version.txt</LogicalName>
     </EmbeddedResource>

--- a/src/FFXIVSpanishPatcher.App/ViewModels/MainViewModel.cs
+++ b/src/FFXIVSpanishPatcher.App/ViewModels/MainViewModel.cs
@@ -17,6 +17,8 @@ namespace FFXIVSpanishPatcher.App.ViewModels;
 public partial class MainViewModel : ObservableObject
 {
     private const string ResourceName = "FFXIVSpanishPatcher.App.translations.dat";
+    private const string ExternalTranslationsMetadataName = "ExternalTranslations";
+    private const string ExternalTranslationsFileName = "translations.dat";
     private const string RecommendedGameVersionResourceName = "FFXIVSpanishPatcher.App.recommended-game-version.txt";
     private const string LandingPageUrl = "https://ffxivspanish.carrd.co/";
 
@@ -32,10 +34,25 @@ public partial class MainViewModel : ObservableObject
     public MainViewModel(IShellServices shell, bool debugLogging = false)
         : this(
             shell,
-            EmbeddedTranslationSource.FromAssemblyResource(typeof(MainViewModel).Assembly, ResourceName),
+            CreateDefaultTranslationSource(),
             LoadRecommendedGameVersion(typeof(MainViewModel).Assembly, RecommendedGameVersionResourceName),
             debugLogging: debugLogging)
     {
+    }
+
+    private static ITranslationSource CreateDefaultTranslationSource()
+    {
+        var assembly = typeof(MainViewModel).Assembly;
+        var useExternalTranslations = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Any(attribute =>
+                attribute.Key.Equals(ExternalTranslationsMetadataName, StringComparison.OrdinalIgnoreCase)
+                && bool.TryParse(attribute.Value, out var enabled)
+                && enabled);
+
+        return useExternalTranslations
+            ? EmbeddedTranslationSource.FromFile(Path.Combine(AppContext.BaseDirectory, ExternalTranslationsFileName))
+            : EmbeddedTranslationSource.FromAssemblyResource(assembly, ResourceName);
     }
 
     public MainViewModel(

--- a/src/FFXIVSpanishPatcher.App/app.manifest
+++ b/src/FFXIVSpanishPatcher.App/app.manifest
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity version="1.0.0.0" name="FFXIVSpanishPatcher.App"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>

--- a/src/FFXIVSpanishPatcher.Pipeline/EmbeddedTranslationSource.cs
+++ b/src/FFXIVSpanishPatcher.Pipeline/EmbeddedTranslationSource.cs
@@ -19,6 +19,10 @@ public sealed class EmbeddedTranslationSource(Func<Stream> openCompressedBlob) :
         => new(() => assembly.GetManifestResourceStream(resourceName)
             ?? throw new InvalidOperationException($"Embedded translation resource not found: {resourceName}"));
 
+    /// <summary>Wraps a Brotli-JSONL blob stored beside a portable application publish.</summary>
+    public static EmbeddedTranslationSource FromFile(string path)
+        => new(() => File.OpenRead(path));
+
     public IReadOnlyList<TranslationEntry> Load()
     {
         using var compressed = _open();

--- a/tests/FFXIVSpanishPatcher.App.Tests/EmbeddedBlobTests.cs
+++ b/tests/FFXIVSpanishPatcher.App.Tests/EmbeddedBlobTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FFXIVSpanishPatcher.App.ViewModels;
 using FFXIVSpanishPatcher.Pipeline;
 using Xunit;
@@ -5,19 +6,27 @@ using Xunit;
 namespace FFXIVSpanishPatcher.App.Tests;
 
 /// <summary>
-/// Guards the build → consume contract for the embedded <c>translations.dat</c>: the compact blob
-/// emitted by <c>tools/XivSpanish.BlobBuilder</c> (field-projected, filtered to approved+gold) must
-/// still deserialize into packageable <c>TranslationEntry</c> rows the pipeline can apply. Loading
-/// the real resource catches a projection that drops a field the model needs.
+/// Guards the build → consume contract for <c>translations.dat</c>, whether the selected build
+/// embeds it or ships it beside the executable. The compact blob emitted by
+/// <c>tools/XivSpanish.BlobBuilder</c> must still deserialize into packageable rows.
 /// </summary>
 public class EmbeddedBlobTests
 {
     private const string ResourceName = "FFXIVSpanishPatcher.App.translations.dat";
 
     [Fact]
-    public void EmbeddedBlob_LoadsPackageableEntries()
+    public void PackagedBlob_LoadsPackageableEntries()
     {
-        var source = EmbeddedTranslationSource.FromAssemblyResource(typeof(MainViewModel).Assembly, ResourceName);
+        var assembly = typeof(MainViewModel).Assembly;
+        var external = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Any(attribute =>
+                attribute.Key.Equals("ExternalTranslations", StringComparison.OrdinalIgnoreCase)
+                && bool.TryParse(attribute.Value, out var enabled)
+                && enabled);
+        var source = external
+            ? EmbeddedTranslationSource.FromFile(Path.Combine(AppContext.BaseDirectory, "translations.dat"))
+            : EmbeddedTranslationSource.FromAssemblyResource(assembly, ResourceName);
 
         var entries = source.Load();
 

--- a/tests/FFXIVSpanishPatcher.Tests/ExdPatcherRegressionTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/ExdPatcherRegressionTests.cs
@@ -6,6 +6,35 @@ namespace FFXIVSpanishPatcher.Tests;
 public sealed class ExdPatcherRegressionTests
 {
     [Fact]
+    public void Patch_PlainQuestDialogue_CreatesPlayerGenderConditional()
+    {
+        const string source = "Could it be!? The Warrior of Darkness!";
+        const string target = "¡<Gender>Guerrera de la Oscuridad<GenderElse>Guerrero de la Oscuridad<GenderEnd>!";
+        var exd = SyntheticExd.BuildExd([(121u, source)]);
+        var replacements = new Dictionary<uint, IReadOnlyList<StringReplacement>>
+        {
+            [121u] = [new StringReplacement(source, target, "Column1")],
+        };
+
+        var result = ExdPatcher.Patch(
+            exd,
+            fixedDataSize: 4,
+            stringColumnOffsets: [0],
+            replacements,
+            stringColumnFieldNames: ["Column1"]);
+
+        Assert.Equal(1, result.Applied);
+        Assert.Empty(result.Missed);
+
+        var patchedRaw = ExdRowReader.ReadRawStrings(result.Bytes, 4, [0])
+            .Single(row => row.RowId == 121u)
+            .Raw;
+        Assert.Equal(
+            "¡<If><Raw>\u0005<Run>Guerrera de la Oscuridad<RunEnd><Run#2>Guerrero de la Oscuridad<RunEnd#2><MacroEnd>!",
+            SeStringTreeTokenizer.TokenizeRawText(patchedRaw));
+    }
+
+    [Fact]
     public void Patch_FieldUnaware_RunAwareSourceFallsBackToTreeTranslate()
     {
         var raw = SeStringTree.Serialize(

--- a/tests/FFXIVSpanishPatcher.Tests/MycWarResultNotebookFieldDriftTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/MycWarResultNotebookFieldDriftTests.cs
@@ -1,0 +1,183 @@
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using XivSpanish.GameData;
+using Xunit;
+
+namespace FFXIVSpanishPatcher.Tests;
+
+/// <summary>
+/// Regression for the MYCWarResultNotebook lore-progreso miss: the corpus was extracted before the
+/// offset-correct field resolver, so its manifest <c>Field</c> labels are PERMUTED relative to the
+/// on-disk EXH String-column offsets. The physical columns are [ordinal 0 = NameJP (offset 8),
+/// ordinal 1 = Name (offset 0), ordinal 2 = Description (offset 4)], but the corpus labels the short
+/// character name as <c>Description</c> and the long biography as <c>NameJP</c>. The packager passes
+/// the offset-correct sidecar names, so the labels point at the wrong ordinal and every replacement
+/// hard-missed (8 applied, 92 missed).
+///
+/// The row is doubly adversarial: the Description is a multi-payload SeString (many
+/// <c>&lt;NewLine#n&gt;</c>) AND the character's short name appears verbatim inside it. A naive
+/// content-match fallback would let the short name hijack the biography column. The fix re-targets a
+/// mislabeled field replacement to the unique column whose FULL content equals its source — an exact
+/// whole-column match, never a substring — so both apply to the right column and nothing is hijacked.
+/// </summary>
+public sealed class MycWarResultNotebookFieldDriftTests
+{
+    // MYCWarResultNotebook layout from the vanilla EXH: 3 String columns at these fixed-data offsets,
+    // in EXH (physical/ordinal) order. ordinal 0 -> offset 8 (NameJP), 1 -> offset 0 (Name),
+    // 2 -> offset 4 (Description).
+    private static readonly int[] StringColumnOffsets = [8, 0, 4];
+    private const int FixedDataSize = 32;
+
+    // Offset-correct field names the packager derives (ResolveByOffset / the .fields.json sidecar).
+    private static readonly string[] OffsetCorrectFieldNames = ["NameJP", "Name", "Description"];
+
+    private const string JpName = "ロフィー・ピル・ポティトゥス";
+    private const string ShortName = "Llofii pyr Potitus";
+
+    // A genuine multi-payload biography that CONTAINS the short name verbatim (the collision trap).
+    private const string DescriptionSource =
+        "Race: Miqo'te<NewLine>Age: 19<NewLine#2>A former imperial mage, Llofii pyr Potitus deserted "
+        + "the IVth Legion.<NewLine#3><NewLine#4>Llofii pyr Potitus surrendered to the Resistance.";
+
+    private const string DescriptionTarget =
+        "Raza: Miqo'te<NewLine>Edad: 19<NewLine#2>Antigua maga imperial, Llofii pyr Potitus desertó "
+        + "de la Legión IV.<NewLine#3><NewLine#4>Llofii pyr Potitus se rindió a la Resistencia.";
+
+    [Fact]
+    public void PermutedFieldLabels_SelfCorrect_BothColumnsApplyWithoutHijack()
+    {
+        var exd = BuildRow();
+
+        // Corpus labels are permuted: the short name is labeled Description (physically ordinal 2),
+        // the long biography is labeled NameJP (physically ordinal 0). Both point at the wrong column.
+        var replacements = new Dictionary<uint, IReadOnlyList<StringReplacement>>
+        {
+            [37] =
+            [
+                new StringReplacement(ShortName, "Llofii pyr Potito", Field: "Description"),
+                new StringReplacement(DescriptionSource, DescriptionTarget, Field: "NameJP"),
+            ],
+        };
+
+        var result = ExdPatcher.Patch(exd, FixedDataSize, StringColumnOffsets, replacements, OffsetCorrectFieldNames);
+
+        // Both replacements self-correct to their real column and apply; nothing missed.
+        Assert.Empty(result.Missed);
+        Assert.Equal(2, result.Applied);
+
+        // The short name landed in the Name column (ordinal 1), translated.
+        Assert.Equal("Llofii pyr Potito", SeStringTreeTokenizer.TokenizeRawText(ReadColumn(result.Bytes, ordinal: 1)));
+
+        // The multi-payload biography landed in the Description column (ordinal 2), tokenized
+        // identically — and was NOT hijacked by the short-name replacement despite containing it.
+        Assert.Equal(DescriptionTarget, SeStringTreeTokenizer.TokenizeRawText(ReadColumn(result.Bytes, ordinal: 2)));
+
+        // The Japanese name column (ordinal 0) is untouched.
+        Assert.Equal(JpName, SeStringTreeTokenizer.TokenizeRawText(ReadColumn(result.Bytes, ordinal: 0)));
+    }
+
+    private static byte[] ReadColumn(byte[] exd, int ordinal)
+        => ExdRowReader
+            .ReadRawStrings(exd, FixedDataSize, StringColumnOffsets)
+            .Where(x => x.RowId == 37 && x.ColumnOrdinal == ordinal)
+            .Select(x => x.Raw)
+            .Single();
+
+    // Builds a single-row Default-variant page with the three MYC String columns at their EXH offsets.
+    private static byte[] BuildRow()
+    {
+        // ordinal -> (fixed-data offset, raw bytes)
+        var columns = new (int Offset, byte[] Value)[]
+        {
+            (8, Encoding.UTF8.GetBytes(JpName)),   // ordinal 0 (NameJP)
+            (0, Encoding.UTF8.GetBytes(ShortName)), // ordinal 1 (Name)
+            (4, SeStringBytes(DescriptionSource)),  // ordinal 2 (Description, multi-payload)
+        };
+
+        using var blob = new MemoryStream();
+        blob.WriteByte(0); // offset 0 = empty string terminator
+        var blobOffsets = new Dictionary<string, uint>();
+        var fixedData = new byte[FixedDataSize];
+
+        foreach (var (offset, value) in columns)
+        {
+            uint stringOffset;
+            if (value.Length == 0)
+            {
+                stringOffset = 0;
+            }
+            else
+            {
+                var key = Convert.ToHexString(value);
+                if (!blobOffsets.TryGetValue(key, out stringOffset))
+                {
+                    stringOffset = (uint)blob.Length;
+                    blob.Write(value);
+                    blob.WriteByte(0);
+                    blobOffsets[key] = stringOffset;
+                }
+            }
+
+            BinaryPrimitives.WriteUInt32BigEndian(fixedData.AsSpan(offset, 4), stringOffset);
+        }
+
+        var stringBlob = blob.ToArray();
+        var dataSize = FixedDataSize + stringBlob.Length;
+
+        const int headerSize = 0x20;
+        var dataStart = headerSize + 8; // one row in the offset table
+
+        using var body = new MemoryStream();
+        var rowHeader = new byte[6];
+        BinaryPrimitives.WriteUInt32BigEndian(rowHeader, (uint)dataSize);
+        BinaryPrimitives.WriteUInt16BigEndian(rowHeader.AsSpan(4), 1);
+        body.Write(rowHeader);
+        body.Write(fixedData);
+        body.Write(stringBlob);
+        var pad = (4 - ((6 + dataSize) % 4)) % 4;
+        for (var p = 0; p < pad; p++)
+        {
+            body.WriteByte(0);
+        }
+
+        var bodyBytes = body.ToArray();
+        var output = new byte[dataStart + bodyBytes.Length];
+        "EXDF"u8.CopyTo(output);
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(0x08), 8);
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(ExdPage.DataSectionSizeOffset), (uint)bodyBytes.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(headerSize), 37u);                 // rowId 37
+        BinaryPrimitives.WriteUInt32BigEndian(output.AsSpan(headerSize + 4), (uint)dataStart);  // offset
+        bodyBytes.CopyTo(output, dataStart);
+        return output;
+    }
+
+    // Builds the raw SeString bytes for a tokenized source whose only payloads are <NewLine> (02 10
+    // 01 03). Verifies the round-trip so the synthetic column matches exactly what the patcher reads.
+    private static byte[] SeStringBytes(string tokenizedSource)
+    {
+        var newline = new byte[] { 0x02, 0x10, 0x01, 0x03 };
+        using var ms = new MemoryStream();
+        var remaining = tokenizedSource;
+        while (remaining.Length > 0)
+        {
+            var open = remaining.IndexOf("<NewLine", StringComparison.Ordinal);
+            if (open < 0)
+            {
+                ms.Write(Encoding.UTF8.GetBytes(remaining));
+                break;
+            }
+
+            ms.Write(Encoding.UTF8.GetBytes(remaining[..open]));
+            ms.Write(newline);
+            var close = remaining.IndexOf('>', open);
+            remaining = remaining[(close + 1)..];
+        }
+
+        var bytes = ms.ToArray();
+        Assert.Equal(tokenizedSource, SeStringTreeTokenizer.TokenizeRawText(bytes));
+        return bytes;
+    }
+}

--- a/tests/FFXIVSpanishPatcher.Tests/PatchPipelineTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/PatchPipelineTests.cs
@@ -130,6 +130,37 @@ public sealed class PatchPipelineTests : IDisposable
     }
 
     [Fact]
+    public void Run_PlayerGenderMacro_PackagesCompiledConditional()
+    {
+        const string sheet = "quest/045/ChrHdb811_04542";
+        const string exdPath = "exd/quest/045/chrhdb811_04542_0_en.exd";
+        const string source = "Could it be!? The Warrior of Darkness!";
+        const string target = "¡<Gender>Guerrera de la Oscuridad<GenderElse>Guerrero de la Oscuridad<GenderEnd>!";
+        var baseSource = new FakeExdSource()
+            .AddPage(exdPath, SyntheticExd.BuildExd([(121u, source)]))
+            .AddLayout(sheet, new ExdLayout(4, [0], 1))
+            .AddFieldNames(sheet, "Column1");
+        var entries = new[] { Approved(sheet, 121u, "Column1", exdPath, source, target) };
+        var pipeline = new PatchPipeline(new ListTranslationSource(entries), new FakePatchBackendFactory(baseSource));
+
+        var result = pipeline.Run(Request());
+
+        Assert.True(result.Success);
+        Assert.Equal(PatchOutcome.Ok, result.Outcome);
+        Assert.Equal(1, result.Applied);
+        Assert.Equal(0, result.Skipped);
+
+        using var archive = ZipFile.OpenRead(result.OutputPath!);
+        var patched = ReadEntryBytes(archive, "files/" + exdPath);
+        var patchedRaw = ExdRowReader.ReadRawStrings(patched, 4, [0])
+            .Single(row => row.RowId == 121u)
+            .Raw;
+        Assert.Equal(
+            "¡<If><Raw>\u0005<Run>Guerrera de la Oscuridad<RunEnd><Run#2>Guerrero de la Oscuridad<RunEnd#2><MacroEnd>!",
+            SeStringTreeTokenizer.TokenizeRawText(patchedRaw));
+    }
+
+    [Fact]
     public void Run_WithDebugLogging_EmitsBroadcastDiagnostics()
     {
         var pipeline = new PatchPipeline(new ListTranslationSource(ApprovedManifest()), new FakePatchBackendFactory(BuildSource()));

--- a/tests/FFXIVSpanishPatcher.Tests/PlayerGenderMacroTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/PlayerGenderMacroTests.cs
@@ -1,0 +1,79 @@
+using XivSpanish.GameData;
+using XivSpanish.Packager;
+using XivSpanish.Translation;
+using Xunit;
+
+namespace FFXIVSpanishPatcher.Tests;
+
+public sealed class PlayerGenderMacroTests
+{
+    [Fact]
+    public void TreeTranslate_PlainSource_CreatesOfficialPlayerGenderConditional()
+    {
+        var vanilla = System.Text.Encoding.UTF8.GetBytes("Welcome, Warrior of Light.");
+        const string target = "Te damos la bienvenida, <Gender>Guerrera<GenderElse>Guerrero<GenderEnd> de la Luz.";
+
+        var translated = SeStringTree.TryTranslate(
+            vanilla,
+            "Welcome, Warrior of Light.",
+            target,
+            out var result,
+            out var reason);
+
+        Assert.True(translated, reason);
+        Assert.Equal(
+            "Te damos la bienvenida, <If><Raw>\u0005<Run>Guerrera<RunEnd><Run#2>Guerrero<RunEnd#2><MacroEnd> de la Luz.",
+            SeStringTreeTokenizer.TokenizeRawText(result));
+
+        var macro = Assert.IsType<SeNode.Macro>(SeStringTree.Parse(result)[1]);
+        Assert.Equal("020817E905FF094775657272657261FF09477565727265726F03", Convert.ToHexString(SeStringTree.SerializeNode(macro)));
+    }
+
+    [Theory]
+    [InlineData("<Gender>Guerrera<GenderEnd>")]
+    [InlineData("<Gender><Num><GenderElse>Guerrero<GenderEnd>")]
+    [InlineData("<Gender>Guerrera<GenderElse><GenderEnd>")]
+    public void ManifestGate_InvalidGenderMacroOnPlainSource_IsUnsafe(string target)
+    {
+        var entry = Entry("Warrior of Light", target);
+
+        var violation = Assert.Single(ManifestSeStringGate.Check([entry]));
+
+        Assert.Equal(SeStringViolationKind.InvalidStandardMacro, Assert.Single(violation.Report.Violations).Kind);
+    }
+
+    [Fact]
+    public void ManifestGate_ValidGenderMacroOnPlainSource_Passes()
+    {
+        var entry = Entry(
+            "Warrior of Light",
+            "<Gender>Guerrera de la Luz<GenderElse>Guerrero de la Luz<GenderEnd>");
+
+        Assert.Empty(ManifestSeStringGate.Check([entry]));
+    }
+
+    [Fact]
+    public void Validator_GenderMacroOnPayloadSource_Fails()
+    {
+        var report = SeStringCompatibilityValidator.Validate(
+            "Welcome, <Num>",
+            "Hola, <Num> <Gender>Guerrera<GenderElse>Guerrero<GenderEnd>");
+
+        Assert.False(report.IsCompatible);
+        Assert.Equal(SeStringViolationKind.InvalidStandardMacro, Assert.Single(report.Violations).Kind);
+    }
+
+    private static TranslationEntry Entry(string source, string target) => new()
+    {
+        Source = source,
+        Target = target,
+        Status = TranslationEntryStatus.Approved,
+        SourceKey = new TranslationSourceKey
+        {
+            Sheet = "quest/045/Test",
+            RowId = 1,
+            Field = "Column1",
+            ExdPath = "exd/quest/045/test_0_en.exd",
+        },
+    };
+}

--- a/tests/FFXIVSpanishPatcher.Tests/TranslationSourceTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/TranslationSourceTests.cs
@@ -76,4 +76,26 @@ public sealed class TranslationSourceTests : IDisposable
         Assert.Equal("a", loaded[0].Target);
         Assert.Equal("b", loaded[1].Target);
     }
+
+    [Fact]
+    public void EmbeddedTranslationSource_FromFileLoadsBrotliJsonl()
+    {
+        var path = Path.Combine(_temp, "translations.dat");
+        using (var output = File.Create(path))
+        using (var brotli = new BrotliStream(output, CompressionLevel.Optimal))
+        using (var writer = new StreamWriter(brotli, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+        {
+            writer.Write(JsonSerializer.Serialize(new TranslationEntry
+            {
+                Source = "External",
+                Target = "Lateral",
+                Status = TranslationEntryStatus.Approved,
+            }));
+        }
+
+        var loaded = EmbeddedTranslationSource.FromFile(path).Load();
+
+        var entry = Assert.Single(loaded);
+        Assert.Equal("Lateral", entry.Target);
+    }
 }

--- a/vendor/XivSpanish.GameData/ExdPatcher.cs
+++ b/vendor/XivSpanish.GameData/ExdPatcher.cs
@@ -232,6 +232,63 @@ public static class ExdPatcher
             }
         }
 
+        // Full current source of each string column (tokenized run-aware, the exact form the
+        // manifest carries for a whole column). Used to VERIFY that a replacement's Field label
+        // actually points at the column that holds its source, and to recover the right column
+        // when it does not (field-name drift, see below). Null entries are out-of-range columns.
+        var columnSource = new string?[stringColumnOffsets.Count];
+        for (var ordinal = 0; ordinal < stringColumnOffsets.Count; ordinal++)
+        {
+            var columnOffset = stringColumnOffsets[ordinal];
+            if (columnOffset + 4 > fixedData.Length)
+            {
+                continue;
+            }
+
+            var strOffset = BinaryPrimitives.ReadUInt32BigEndian(fixedData.AsSpan(columnOffset, 4));
+            columnSource[ordinal] = SeStringTreeTokenizer.TokenizeRawText(
+                ReadNulTerminatedBytes(stringArea, (int)strOffset));
+        }
+
+        var fieldTargeted = new Dictionary<int, StringReplacement>();
+
+        // Resolves the string-column ordinal a non-empty field-targeted replacement should write.
+        // The label resolves to <paramref name="labeled"/>, but a corpus extracted before the
+        // offset-correct field resolver can carry field labels PERMUTED relative to the on-disk
+        // column offsets (e.g. MYCWarResultNotebook, whose "Description"/"NameJP" labels point at
+        // the wrong ordinal). When the labeled column does not actually hold the source, retarget
+        // to the unique OTHER column whose FULL content equals the source — an exact whole-column
+        // match, never a substring, so this cannot reintroduce the substring collision (a short
+        // name that appears verbatim inside its own long biography stays out of the bio column).
+        // Falls back to the labeled ordinal when the source is genuinely absent or the match is
+        // ambiguous, so Phase A still reports a precise miss instead of guessing.
+        int ResolveFieldOrdinal(int labeled, string source)
+        {
+            if (string.Equals(columnSource[labeled], source, StringComparison.Ordinal))
+            {
+                return labeled;
+            }
+
+            var found = -1;
+            for (var ordinal = 0; ordinal < columnSource.Length; ordinal++)
+            {
+                if (fieldTargeted.ContainsKey(ordinal)
+                    || !string.Equals(columnSource[ordinal], source, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (found >= 0)
+                {
+                    return labeled; // Ambiguous: two columns hold the source. Keep the label.
+                }
+
+                found = ordinal;
+            }
+
+            return found >= 0 ? found : labeled;
+        }
+
         // Partition replacements:
         //  - fieldTargeted[ordinal]: a replacement whose Field resolves to that exact column. It
         //    is applied to ONLY that column (fixing the substring collision: a Singular source
@@ -239,18 +296,25 @@ public static class ExdPatcher
         //  - contentMatched: non-empty source, no usable field → legacy content matching across
         //    the remaining (non-field-targeted) columns.
         //  - emptyWrites: empty source, no usable field → legacy write-at-offset.
-        var fieldTargeted = new Dictionary<int, StringReplacement>();
         var contentMatched = new List<StringReplacement>();
         var emptyWrites = new Queue<StringReplacement>();
         foreach (var rep in rowReplacements)
         {
             if (rep.Field is not null && fieldToOrdinal.TryGetValue(rep.Field, out var ordinal)
-                && stringColumnOffsets[ordinal] + 4 <= fixedData.Length
-                && !fieldTargeted.ContainsKey(ordinal))
+                && stringColumnOffsets[ordinal] + 4 <= fixedData.Length)
             {
-                fieldTargeted[ordinal] = rep;
+                // A non-empty source verifies/self-corrects its target column by exact content;
+                // an empty source (write-at-offset) keeps the literal label — an empty column has
+                // no content to match against, so retargeting it is undefined.
+                var target = rep.Source.Length == 0 ? ordinal : ResolveFieldOrdinal(ordinal, rep.Source);
+                if (!fieldTargeted.ContainsKey(target))
+                {
+                    fieldTargeted[target] = rep;
+                    continue;
+                }
             }
-            else if (rep.Source.Length == 0)
+
+            if (rep.Source.Length == 0)
             {
                 emptyWrites.Enqueue(rep);
             }

--- a/vendor/XivSpanish.GameData/SeStringCompatibilityValidator.cs
+++ b/vendor/XivSpanish.GameData/SeStringCompatibilityValidator.cs
@@ -38,6 +38,9 @@ public enum SeStringViolationKind
     /// before any literal may change; identical literals (status-only edits) remain safe.
     /// </summary>
     StaleRunLength,
+
+    /// <summary>An allow-listed target-authored macro has invalid syntax or was added to a payload-bearing source.</summary>
+    InvalidStandardMacro,
 }
 
 /// <summary>
@@ -120,6 +123,11 @@ public static partial class SeStringCompatibilityValidator
 
         var violations = new List<SeStringViolation>();
 
+        if (SeStringStandardMacros.HasReservedDelimiter(target))
+        {
+            return ValidateStandardMacros(source, target);
+        }
+
         var sourceAtoms = ExtractAtoms(source);
         var targetAtoms = ExtractAtoms(target);
 
@@ -131,6 +139,56 @@ public static partial class SeStringCompatibilityValidator
         CheckStaleRunLength(source, target, sourceAtoms, targetAtoms, violations);
 
         return new SeStringCompatibilityReport(violations);
+    }
+
+    private static SeStringCompatibilityReport ValidateStandardMacros(string source, string target)
+    {
+        var violations = new List<SeStringViolation>();
+        if (HasPayloads(source))
+        {
+            violations.Add(new SeStringViolation(
+                SeStringViolationKind.InvalidStandardMacro,
+                GenderToken(target),
+                target.IndexOf(SeStringStandardMacros.GenderOpen, StringComparison.Ordinal),
+                "standard target macros may only be added when the source SeString is plain text"));
+            return new SeStringCompatibilityReport(violations);
+        }
+
+        if (!SeStringStandardMacros.TryParse(target, out _, out var reason))
+        {
+            violations.Add(new SeStringViolation(
+                SeStringViolationKind.InvalidStandardMacro,
+                GenderToken(target),
+                FirstGenderDelimiter(target),
+                reason ?? "invalid standard target macro"));
+            return new SeStringCompatibilityReport(violations);
+        }
+
+        CheckControlChars(source, target, violations);
+        return new SeStringCompatibilityReport(violations);
+    }
+
+    private static string? GenderToken(string target)
+    {
+        var position = FirstGenderDelimiter(target);
+        if (position < 0)
+        {
+            return null;
+        }
+
+        var end = target.IndexOf(SeStringTokenizer.TokenClose, position);
+        return end < 0 ? "<" : target[position..(end + 1)];
+    }
+
+    private static int FirstGenderDelimiter(string target)
+    {
+        var positions = new[]
+        {
+            target.IndexOf(SeStringStandardMacros.GenderOpen, StringComparison.Ordinal),
+            target.IndexOf(SeStringStandardMacros.GenderElse, StringComparison.Ordinal),
+            target.IndexOf(SeStringStandardMacros.GenderEnd, StringComparison.Ordinal),
+        };
+        return positions.Where(position => position >= 0).DefaultIfEmpty(-1).Min();
     }
 
     /// <summary>One payload token occurrence: its exact text (e.g. "&lt;Num#2&gt;") and char index.</summary>

--- a/vendor/XivSpanish.GameData/SeStringParser.cs
+++ b/vendor/XivSpanish.GameData/SeStringParser.cs
@@ -332,6 +332,15 @@ public static class SeStringParser
             return false;
         }
 
+        // Target-authored standard macros require the run-aware tree so their binary framing and
+        // length-prefixed branches are synthesized structurally. Never write their authoring tags
+        // as visible literal text through the flat replacement path.
+        if (SeStringStandardMacros.HasReservedDelimiter(target))
+        {
+            reason = "target contains standard macros requiring run-aware translation";
+            return false;
+        }
+
         var sourceTokens = SeStringTokenizer.FindTokenReferences(source);
         var targetTokens = SeStringTokenizer.FindTokenReferences(target);
         if (!TokenReferencesEqual(sourceTokens, targetTokens))
@@ -440,6 +449,12 @@ public static class SeStringParser
         if (string.IsNullOrEmpty(source))
         {
             reason = "source is empty";
+            return false;
+        }
+
+        if (SeStringStandardMacros.HasReservedDelimiter(target))
+        {
+            reason = "target contains standard macros requiring run-aware translation";
             return false;
         }
 

--- a/vendor/XivSpanish.GameData/SeStringStandardMacros.cs
+++ b/vendor/XivSpanish.GameData/SeStringStandardMacros.cs
@@ -1,0 +1,182 @@
+using System.Text;
+
+namespace XivSpanish.GameData;
+
+/// <summary>
+/// Parses the small, explicitly allow-listed set of SeString macros that a translation target may
+/// add even when the source language is plain text. This is deliberately separate from the normal
+/// token map: arbitrary payload invention remains impossible.
+/// </summary>
+public static class SeStringStandardMacros
+{
+    public const string GenderOpen = "<Gender>";
+    public const string GenderElse = "<GenderElse>";
+    public const string GenderEnd = "<GenderEnd>";
+
+    private const byte IfMacroCode = 0x08;
+    private const byte GlobalNumberExpression = 0xE9;
+    private const char PlayerGenderParameter = '\x05'; // packed integer 4: player gender
+
+    /// <summary>True when text contains any reserved standard-macro delimiter.</summary>
+    public static bool HasReservedDelimiter(string text)
+        => FindUnescaped(text, GenderOpen, 0) >= 0
+            || FindUnescaped(text, GenderElse, 0) >= 0
+            || FindUnescaped(text, GenderEnd, 0) >= 0;
+
+    /// <summary>
+    /// Parses target authoring syntax into a run-aware SeString tree. The supported construct is
+    /// <c>&lt;Gender&gt;female&lt;GenderElse&gt;male&lt;GenderEnd&gt;</c>. Its binary form matches the
+    /// official French localization: <c>If(GlobalNumber(4), female, male)</c> with both branches
+    /// encoded as length-prefixed runs.
+    /// </summary>
+    public static bool TryParse(string text, out List<SeNode> nodes, out string? reason)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        nodes = [];
+        reason = null;
+
+        var literal = new StringBuilder();
+        var position = 0;
+        while (position < text.Length)
+        {
+            if (text[position] != SeStringTokenizer.TokenOpen)
+            {
+                literal.Append(text[position++]);
+                continue;
+            }
+
+            if (position + 1 < text.Length && text[position + 1] == SeStringTokenizer.TokenOpen)
+            {
+                literal.Append(SeStringTokenizer.TokenOpen);
+                position += 2;
+                continue;
+            }
+
+            if (!text.AsSpan(position).StartsWith(GenderOpen, StringComparison.Ordinal))
+            {
+                reason = $"unsupported or stray '<' at index {position} in standard-macro target";
+                nodes = [];
+                return false;
+            }
+
+            FlushLiteral(nodes, literal);
+            var femaleStart = position + GenderOpen.Length;
+            var elsePosition = FindUnescaped(text, GenderElse, femaleStart);
+            var nestedPosition = FindUnescaped(text, GenderOpen, femaleStart);
+            if (elsePosition < 0 || (nestedPosition >= 0 && nestedPosition < elsePosition))
+            {
+                reason = $"{GenderOpen} at index {position} has no valid {GenderElse}";
+                nodes = [];
+                return false;
+            }
+
+            var maleStart = elsePosition + GenderElse.Length;
+            var endPosition = FindUnescaped(text, GenderEnd, maleStart);
+            nestedPosition = FindUnescaped(text, GenderOpen, maleStart);
+            if (endPosition < 0 || (nestedPosition >= 0 && nestedPosition < endPosition))
+            {
+                reason = $"{GenderOpen} at index {position} has no valid {GenderEnd}";
+                nodes = [];
+                return false;
+            }
+
+            var femaleRaw = text[femaleStart..elsePosition];
+            var maleRaw = text[maleStart..endPosition];
+            if (!TryDecodeLiteralBranch(femaleRaw, out var female, out reason)
+                || !TryDecodeLiteralBranch(maleRaw, out var male, out reason))
+            {
+                nodes = [];
+                return false;
+            }
+
+            if (female.Length == 0 || male.Length == 0)
+            {
+                reason = "gender conditional requires non-empty female and male branches";
+                nodes = [];
+                return false;
+            }
+
+            nodes.Add(new SeNode.Macro(
+                IfMacroCode,
+                [
+                    new SeNode.RawByte(GlobalNumberExpression),
+                    new SeNode.Literal(PlayerGenderParameter.ToString()),
+                    new SeNode.Run([new SeNode.Literal(female)], 0x01),
+                    new SeNode.Run([new SeNode.Literal(male)], 0x01),
+                ],
+                0x01));
+
+            position = endPosition + GenderEnd.Length;
+        }
+
+        FlushLiteral(nodes, literal);
+        return true;
+    }
+
+    private static void FlushLiteral(List<SeNode> nodes, StringBuilder literal)
+    {
+        if (literal.Length == 0)
+        {
+            return;
+        }
+
+        nodes.Add(new SeNode.Literal(literal.ToString()));
+        literal.Clear();
+    }
+
+    private static int FindUnescaped(string text, string delimiter, int start)
+    {
+        var position = start;
+        while (position < text.Length)
+        {
+            var found = text.IndexOf(delimiter, position, StringComparison.Ordinal);
+            if (found < 0)
+            {
+                return -1;
+            }
+
+            var precedingOpenCount = 0;
+            for (var i = found - 1; i >= 0 && text[i] == SeStringTokenizer.TokenOpen; i--)
+            {
+                precedingOpenCount++;
+            }
+
+            if (precedingOpenCount % 2 == 0)
+            {
+                return found;
+            }
+
+            position = found + delimiter.Length;
+        }
+
+        return -1;
+    }
+
+    private static bool TryDecodeLiteralBranch(string text, out string decoded, out string? reason)
+    {
+        var literal = new StringBuilder();
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] != SeStringTokenizer.TokenOpen)
+            {
+                literal.Append(text[i]);
+                continue;
+            }
+
+            if (i + 1 < text.Length && text[i + 1] == SeStringTokenizer.TokenOpen)
+            {
+                literal.Append(SeStringTokenizer.TokenOpen);
+                i++;
+                continue;
+            }
+
+            decoded = string.Empty;
+            reason = "gender conditional branches must be literal text; nested payloads are not allowed";
+            return false;
+        }
+
+        decoded = literal.ToString();
+        reason = null;
+        return true;
+    }
+}

--- a/vendor/XivSpanish.GameData/SeStringTree.cs
+++ b/vendor/XivSpanish.GameData/SeStringTree.cs
@@ -96,7 +96,23 @@ public static class SeStringTree
             return false;
         }
 
-        if (!SeStringTreeTokenizer.TryDetokenize(target, tok.Tokens, out var rebuilt, out var detokenReason))
+        List<SeNode> rebuilt;
+        string? detokenReason;
+        if (SeStringStandardMacros.HasReservedDelimiter(target))
+        {
+            if (tok.Tokens.Count != 0)
+            {
+                reason = "standard target macros may only be added when the source SeString is plain text";
+                return false;
+            }
+
+            if (!SeStringStandardMacros.TryParse(target, out rebuilt, out detokenReason))
+            {
+                reason = detokenReason ?? "could not parse standard target macros";
+                return false;
+            }
+        }
+        else if (!SeStringTreeTokenizer.TryDetokenize(target, tok.Tokens, out rebuilt, out detokenReason))
         {
             reason = detokenReason ?? "could not detokenize target";
             return false;

--- a/vendor/XivSpanish.Packaging/ManifestSeStringGate.cs
+++ b/vendor/XivSpanish.Packaging/ManifestSeStringGate.cs
@@ -36,9 +36,11 @@ public sealed record ManifestSeStringViolation(TranslationEntry Entry, SeStringC
 
 /// <summary>
 /// Hard SeString gate run at manifest load, before any build work (T-19-03). Every entry that
-/// would be packaged and whose SOURCE carries payload tokens or raw macro control bytes must pass
+/// would be packaged and whose source carries payload machinery, or whose target carries an
+/// allow-listed standard macro, must pass
 /// <see cref="SeStringCompatibilityValidator"/>; otherwise the build fails (exit ≠ 0) listing ALL
-/// offending rows — the check never stops at the first violation. Plain-text rows pass trivially.
+/// offending rows — the check never stops at the first violation. Plain-text rows without a
+/// reserved target macro pass trivially.
 /// Mirrors the XivSpanish.Jsonl T-19-02 gate, including the loudly-logged
 /// <c>--force-sestring</c> override.
 /// </summary>
@@ -48,7 +50,8 @@ public static class ManifestSeStringGate
     public const string OverrideMarker = "!! SESTRING OVERRIDE (--force-sestring)";
 
     /// <summary>
-    /// Checks every entry and collects ALL violations. Only payload-bearing sources are validated;
+    /// Checks every entry and collects ALL violations. Payload-bearing sources and targets carrying
+    /// reserved standard-macro delimiters are validated;
     /// entries with a null/empty target are skipped (they are not packageable and are reported as
     /// skips elsewhere). The caller decides whether the manifest is rejected or force-overridden.
     /// </summary>
@@ -57,7 +60,9 @@ public static class ManifestSeStringGate
         var violations = new List<ManifestSeStringViolation>();
         foreach (var entry in entries)
         {
-            if (string.IsNullOrEmpty(entry.Target) || !SeStringCompatibilityValidator.HasPayloads(entry.Source))
+            if (string.IsNullOrEmpty(entry.Target)
+                || (!SeStringCompatibilityValidator.HasPayloads(entry.Source)
+                    && !SeStringStandardMacros.HasReservedDelimiter(entry.Target)))
             {
                 continue;
             }


### PR DESCRIPTION
## v0.2.3

- Flexión de género del personaje: el patcher ahora genera condicionales de género nativos del juego, de forma que los diálogos concuerdan con el género del personaje del jugador (Guerrero/Guerrera de la Luz, aventurero/aventurera...).
- Actualizado el corpus de traducciones embebido (~47.000 líneas nuevas aprobadas):
  - Misiones de gremio post-Heavensward de TODAS las clases de crafteo y recolección: Alquimista, Minero, Carpintero, Curtidor, Armero, Pescador, Culinario, Botánico y Herrero (~90 hojas).
  - Historia principal ARR: parches 2.1 a 2.3 (bloques `GaiUse211-216` y lote `msq22`: apertura, Ul'dah y refugiados de Doma).
  - Lore y progreso: `MJIProgress` (Isla del Vagabundo), `WKSCosmoToolName` y arranque de `WKSMechaEventData` (Cosmic Exploration).
- Progreso total: 473.962/802.280 líneas (59,1%, antes 53,0%). Crafting/recolección al 74,2%, minijuegos/eventos al 99,8%, lore/diarios y eventos explícitos al 100%.
- Barrido tipográfico de todo el corpus: guiones de caja (U+2500) sustituidos por rayas (—) según la puntuación española.
- Ronda de canon ratificada por entrevista: decisiones de terminología y estilo aplicadas de forma coherente a todo el corpus.
- Correcciones de parcheo (vendor): auto-corrección de etiquetas de campo permutadas en `ExdPatcher` — filas que antes fallaban en silencio (biografías del Bozja Notebook, `Perform`, `Snipe`, `QTE`...) ahora se aplican al 100%.
- Arreglado falso positivo en la verificación del patcher.
