### PR TITLE
v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Resumen de todos los cambios relevantes del proyecto.
 
+## v0.2.4
+
+- Actualizado el corpus de traducciones embebido con **16.032 líneas nuevas aprobadas**. El progreso total alcanza **489.994/802.221 líneas traducibles (61,1 %)**, frente al 59,1 % de v0.2.3.
+- Gran ampliación de misiones y diálogos de *A Realm Reborn*:
+  - Más tramos de la historia principal de ARR
+  - Nuevas misiones secundarias de las cadenas de quests de ARR
+  - Misiones de las tribus bestia amalj'aa, sahagin e ixal
+  - Misiones de job de *Heavensward* de astrólogo, caballero oscuro, monje, paladín e invocador, además del arco de las armas reliquia.
+  - Más contenido de eventos estacionales y textos de Exploración Cósmica.
+- Terminología revisada en todo el corpus: **Velo / Velo Negro** pasa a ser **Espesura / Espesura Negra**, con sus variantes regionales y referencias relacionadas actualizadas de forma consistente.
+- Actualizadas dependencias y herramientas de desarrollo: SDK de .NET 10.0.302, Lumina 7.6.0, Lumina.Excel 7.5.0, Tmds.DBus.Protocol y Microsoft.NET.Test.Sdk. Añadida comprobación semanal de actualizaciones con Dependabot.
+
 ## v0.2.3
 
 - Flexión de género del personaje: el patcher ahora genera condicionales de género nativos del juego, de forma que los diálogos concuerdan con el género del personaje del jugador (Guerrero/Guerrera de la Luz, aventurero/aventurera...).

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ traducibles exactas.
 
 | Métrica | Valor | Avance |
 | --- | ---: | --- |
-| Avance total por líneas | 473.962/802.280 (59,1%) | ![59,1%](https://geps.dev/progress/59.1?barColor=f1c232) |
-| Hojas OK | 2.152/6.956 (30,9%) | ![30,9%](https://geps.dev/progress/30.9?barColor=f0883e) |
+| Avance total por líneas | 489.994/802.221 (61,1%) | ![61,1%](https://geps.dev/progress/61.1?barColor=f1c232) |
+| Hojas OK | 2.606/6.956 (37,5%) | ![37,5%](https://geps.dev/progress/37.5?barColor=f0883e) |
 
 | Área | Líneas traducidas | Avance |
 | --- | ---: | --- |
@@ -36,7 +36,7 @@ traducibles exactas.
 | Crafting / recolección / progreso | 5.463/7.367 (74,2%) | ![74,2%](https://geps.dev/progress/74.2?barColor=f1c232) |
 | Lore / diarios / colecciones | 20.745/20.745 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
 | Minijuegos / eventos / perfil | 7.384/7.400 (99,8%) | ![99,8%](https://geps.dev/progress/99.8?barColor=2ea043) |
-| Guion - quests | 58.710/261.923 (22,4%) | ![22,4%](https://geps.dev/progress/22.4?barColor=f0883e) |
+| Guion - quests | 74.742/261.863 (28,5%) | ![28,5%](https://geps.dev/progress/28.5?barColor=f0883e) |
 | Guion - cinemáticas | 1.518/26.426 (5,7%) | ![5,7%](https://geps.dev/progress/5.7?barColor=da3633) |
 | Guion - custom talk/NPC | 12.443/28.367 (43,9%) | ![43,9%](https://geps.dev/progress/43.9?barColor=f0883e) |
 | Guion - eventos explícitos | 1.469/1.469 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ef8370414f6f5fa4e44c396cdaa600628d4db2ebb48def0b0020235298c6fb3
-size 17707453
+oid sha256:102fdc22f9fb0cf6fd7f72c7dfcc8e1925e65ff7b33e20749990e7848c501f49
+size 17708236

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6cf245d07f9ab40e929467fff59406cba402ad8467f31dacf9c0e690aaad1db
-size 16381766
+oid sha256:2ef8370414f6f5fa4e44c396cdaa600628d4db2ebb48def0b0020235298c6fb3
+size 17707453


### PR DESCRIPTION
## v0.2.4

- Actualizado el corpus de traducciones embebido con **16.032 líneas nuevas aprobadas**. El progreso total alcanza **489.994/802.221 líneas traducibles (61,1 %)**, frente al 59,1 % de v0.2.3.
- Gran ampliación de misiones y diálogos de *A Realm Reborn*:
  - Más tramos de la historia principal de ARR
  - Nuevas misiones secundarias de las cadenas de quests de ARR
  - Misiones de las tribus bestia amalj'aa, sahagin e ixal
  - Misiones de job de *Heavensward* de astrólogo, caballero oscuro, monje, paladín e invocador, además del arco de las armas reliquia.
  - Más contenido de eventos estacionales y textos de Exploración Cósmica.
- Terminología revisada en todo el corpus: **Velo / Velo Negro** pasa a ser **Espesura / Espesura Negra**, con sus variantes regionales y referencias relacionadas actualizadas de forma consistente.
- Actualizadas dependencias y herramientas de desarrollo: SDK de .NET 10.0.302, Lumina 7.6.0, Lumina.Excel 7.5.0, Tmds.DBus.Protocol y Microsoft.NET.Test.Sdk. Añadida comprobación semanal de actualizaciones con Dependabot.
