### PR TITLE
v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Resumen de todos los cambios relevantes del proyecto.
 
+## v0.3.2
+
+- Corregido el crash al abrir «Cambiar de Mundo» desde un aetheryte. El serializador SeString ahora
+  usa la codificación extendida correcta cuando un cuerpo macro o run supera 206 bytes, sin acortar
+  ni omitir la traducción española del panel.
+
 ## v0.3.1
 
 - Revisión exhaustiva trilingüe (inglés, francés y alemán) de las **105.113 filas aprobadas** de

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -83,6 +83,20 @@ flowchart LR
 `IPatchBackend.ResolveExd` devuelve `Resolved`, `MissingSheet` o `UnresolvedRow`. El pipeline sigue
 con las páginas válidas, emite sus avisos y devuelve estadísticas estructuradas.
 
+### Contrato binario SeString
+
+Las longitudes de cuerpos macro y runs usan enteros compactos del cliente:
+
+- Los bytes de tipo `0x01..0xCF` son enteros inline. Como almacenan `longitud + 1`, `0xCF`
+  representa la longitud inline máxima: 206 bytes.
+- `0xD0..0xEF` son tipos de expresión, no longitudes. Nunca deben emitirse como prefijo.
+- Desde 207 bytes se usa la forma extendida `0xF0..0xFE`; por ejemplo, 207 se codifica `F0 CF`.
+
+`SeStringTree` recalcula de dentro hacia fuera todos los prefijos afectados. No se acortan
+traducciones para evitar esta frontera. Las pruebas deben fijar bytes esperados en 206/207 y cubrir
+un EXD sintético completo: validar solo encode y decode con el mismo codec puede ocultar un error
+autoconsistente que el cliente interpretaría como una expresión.
+
 La baja coincidencia solo puede ignorarse si la GUI ha comparado dos versiones conocidas y el
 usuario ha confirmado `BestEffortVersionMismatch`. En modo estricto, el guard conserva su función de
 detectar una base contaminada o incompatible.

--- a/tests/FFXIVSpanishPatcher.Tests/SeStringPackedLengthTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/SeStringPackedLengthTests.cs
@@ -1,0 +1,94 @@
+using XivSpanish.GameData;
+using Xunit;
+
+namespace FFXIVSpanishPatcher.Tests;
+
+public sealed class SeStringPackedLengthTests
+{
+    [Fact]
+    public void Parser_InlineLengthBoundaryEndsAtTypeByteCf()
+    {
+        var inline = new byte[] { 0xFF, 0xCF }
+            .Concat(Enumerable.Repeat((byte)'a', 206))
+            .Append((byte)0)
+            .ToArray();
+        var payload = Assert.IsType<SeStringSegment.Payload>(Assert.Single(SeStringParser.Parse(inline)));
+        Assert.Equal(208, payload.Bytes.Length);
+
+        foreach (var expressionType in new byte[] { 0xD0, 0xD7, 0xDF, 0xEF })
+        {
+            var segments = SeStringParser.Parse([0xFF, expressionType, (byte)'x', 0]);
+            Assert.Equal([0xFF], Assert.IsType<SeStringSegment.Payload>(segments[0]).Bytes);
+        }
+    }
+
+    [Fact]
+    public void Serializer_Length207UsesExtendedPackedInteger()
+    {
+        var inline = SeStringTree.Serialize(
+            [new SeNode.Run([new SeNode.Literal(new string('a', 206))], MarkerByte: 0x10)]);
+        var extended = SeStringTree.Serialize(
+            [new SeNode.Run([new SeNode.Literal(new string('a', 207))], MarkerByte: 0x10)]);
+
+        Assert.Equal([0xFF, 0xCF], inline[..2]);
+        Assert.Equal([0xFF, 0xF0, 0xCF], extended[..3]);
+        Assert.Equal(inline, SeStringTree.Serialize(SeStringTree.Parse(inline)));
+        Assert.Equal(extended, SeStringTree.Serialize(SeStringTree.Parse(extended)));
+    }
+
+    [Fact]
+    public void Patcher_NestedRunCrossingBoundaryUsesExtendedPrefixes()
+    {
+        var vanillaWithTerminator = SeStringTree.Serialize(
+        [
+            new SeNode.Macro(
+                Code: 0x08,
+                Children:
+                [
+                    new SeNode.Run([new SeNode.Literal(new string('a', 184))], MarkerByte: 0xB9),
+                    new SeNode.Literal("xxxxxx"),
+                ],
+                LengthMarker: 0xC1),
+        ]);
+        var vanilla = vanillaWithTerminator[..^1];
+        var source = SeStringTreeTokenizer.TokenizeRawText(vanilla);
+        var target = source.Replace(new string('a', 184), new string('b', 214), StringComparison.Ordinal);
+        var exd = SyntheticExd.BuildExdRaw([(12514u, [vanilla])], fixedSize: 4);
+        var replacements = new Dictionary<uint, IReadOnlyList<StringReplacement>>
+        {
+            [12514u] = [new StringReplacement(source, target, "Text")],
+        };
+
+        var result = ExdPatcher.Patch(
+            exd,
+            fixedDataSize: 4,
+            stringColumnOffsets: [0],
+            replacements,
+            stringColumnFieldNames: ["Text"]);
+
+        Assert.Equal(1, result.Applied);
+        Assert.Empty(result.Missed);
+
+        var patched = ExdRowReader.ReadRawStrings(result.Bytes, 4, [0])
+            .Single(row => row.RowId == 12514u)
+            .Raw;
+        Assert.Equal(target, SeStringTreeTokenizer.TokenizeRawText(patched));
+        Assert.True(ContainsSequence(patched, [0x02, 0x08, 0xF0, 0xDF]));
+        Assert.True(ContainsSequence(patched, [0xFF, 0xF0, 0xD6]));
+        Assert.False(ContainsSequence(patched, [0x02, 0x08, 0xDF]));
+        Assert.False(ContainsSequence(patched, [0xFF, 0xD7]));
+    }
+
+    private static bool ContainsSequence(byte[] bytes, byte[] sequence)
+    {
+        for (var i = 0; i <= bytes.Length - sequence.Length; i++)
+        {
+            if (bytes.AsSpan(i, sequence.Length).SequenceEqual(sequence))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/vendor/XivSpanish.GameData/SeStringParser.cs
+++ b/vendor/XivSpanish.GameData/SeStringParser.cs
@@ -212,7 +212,8 @@ public static class SeStringParser
     /// Decodes the SeString integer that prefixes a 0xFF string run, giving the run body length in
     /// bytes and the index where the body starts. Encoding (matches the client/Lumina):
     /// <list type="bullet">
-    ///   <item>A byte <c>0x01..0xEF</c> is an inline value: length = <c>byte - 1</c>.</item>
+    ///   <item>A type byte <c>0x01..0xCF</c> is an inline value: length = <c>byte - 1</c>.</item>
+    ///   <item><c>0xD0..0xEF</c> are expression types, not inline integer values.</item>
     ///   <item><c>0xF0..0xFE</c> is a marker whose low nibble (of <c>marker + 1</c>) is a bitmask of
     ///   which of up to four big-endian value bytes follow (bit3→byte&lt;&lt;24 … bit0→byte).</item>
     /// </list>
@@ -228,7 +229,7 @@ public static class SeStringParser
         }
 
         var marker = bytes[index];
-        if (marker is >= 0x01 and <= 0xEF)
+        if (marker is >= 0x01 and <= 0xCF)
         {
             length = marker - 1;
             bodyStart = index + 1;

--- a/vendor/XivSpanish.GameData/SeStringTree.cs
+++ b/vendor/XivSpanish.GameData/SeStringTree.cs
@@ -162,7 +162,7 @@ public static class SeStringTree
                 else
                 {
                     // Not a delimitable macro chunk: this 0x02 is a macro EXPRESSION byte (the packint
-                    // integer encoding reuses 0x01..0xEF inline values, so an If/Switch condition can
+                    // integer encoding reuses 0x01..0xCF inline values, so an If/Switch condition can
                     // legitimately contain 0x02 — e.g. `e1 e8 03 02` in Addon row 2513). Emit it as a
                     // single opaque RawByte and keep parsing, so the 0xFF runs that follow are modeled
                     // structurally instead of being swallowed by an opaque scan-to-0x03 (which truncated
@@ -328,8 +328,10 @@ public static class SeStringTree
     }
 
     /// <summary>
-    /// Decodes the run length prefix. <c>0x01..0xEF</c> is inline (value = byte − 1); <c>0xF0..0xFE</c>
-    /// is a marker whose low nibble (of marker+1) is a bitmask of big-endian value bytes that follow.
+    /// Decodes the run length prefix. Type bytes <c>0x01..0xCF</c> are inline
+    /// (value = byte − 1); <c>0xD0..0xEF</c> are expression types and must not be consumed as
+    /// lengths; <c>0xF0..0xFE</c> is a marker whose low nibble (of marker+1) is a bitmask of
+    /// big-endian value bytes that follow.
     /// </summary>
     internal static bool TryReadRunLength(byte[] bytes, int index, out int length, out int bodyStart, out byte marker)
     {
@@ -342,7 +344,7 @@ public static class SeStringTree
         }
 
         marker = bytes[index];
-        if (marker is >= 0x01 and <= 0xEF)
+        if (marker is >= 0x01 and <= 0xCF)
         {
             length = marker - 1;
             bodyStart = index + 1;
@@ -367,13 +369,14 @@ public static class SeStringTree
     }
 
     // Re-encodes a run length, preserving the original marker form when the value still fits (so an
-    // unchanged run round-trips byte-identically), widening to the smallest contiguous-low marker
-    // (0xF0/0xF2/0xF6/0xFE) otherwise.
+    // unchanged run round-trips byte-identically). The inline form stops at type byte 0xCF
+    // (length 206); 0xD0..0xEF are expression types, so length 207 and above must use an extended
+    // 0xF0..0xFE marker.
     private static byte[] EncodeRunLength(int value, byte originalMarker)
     {
-        if (originalMarker is >= 0x01 and <= 0xEF)
+        if (originalMarker is >= 0x01 and <= 0xCF)
         {
-            if (value is >= 0 and <= 0xEE)
+            if (value is >= 0 and <= 0xCE)
             {
                 return [(byte)(value + 1)];
             }
@@ -383,7 +386,7 @@ public static class SeStringTree
             return EmitMarker(value, originalMarker);
         }
 
-        if (value <= 0xEE) { return [(byte)(value + 1)]; }
+        if (value <= 0xCE) { return [(byte)(value + 1)]; }
         if (value <= 0xFF) { return EmitMarker(value, 0xF0); }
         if (value <= 0xFFFF) { return EmitMarker(value, 0xF2); }
         if (value <= 0xFFFFFF) { return EmitMarker(value, 0xF6); }


### PR DESCRIPTION
## v0.3.2

- Corregido el crash al abrir «Cambiar de Mundo» desde un aetheryte. El serializador SeString ahora usa la codificación extendida correcta cuando un cuerpo macro o run supera 206 bytes, sin acortar ni omitir la traducción española del panel.

(Muchas gracias a la persona que me notificó el crasheo)
