### PR TITLE
v0.3.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ dotnet publish src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj -c Rel
 dotnet publish src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj -c Release -r linux-x64 --self-contained -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
 ```
 
-El proyecto usa `global.json` con SDK `10.0.302` y `rollForward: latestFeature`. Los
+El proyecto usa `global.json` con SDK `10.0.302` fijado mediante `rollForward: disable`. Los
 `packages.lock.json` estan versionados; CI y releases restauran con `--locked-mode`.
 
 La app publica con trimming activado (`PublishTrimmed=true`, `TrimMode=full`) y rootea `Lumina` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Resumen de todos los cambios relevantes del proyecto.
 
+## v0.3.3
+
+- Actualizado el corpus con **17.648 líneas nuevas aprobadas** y **545 hojas completadas**. El
+  progreso global alcanza **534.529/808.960 líneas traducibles (66,1 %)** y
+  **3.490/6.986 hojas completadas (50,0 %)**.
+- Gran avance de *Heavensward*: pasa del **18,9 % al 78,5 %**, con
+  **19.907/25.274 líneas traducidas**.
+- Traducidos amplios bloques de la historia principal de *Heavensward* (`HeaVna` y `HeaVnz`),
+  incluido el avance parcial del lote actual hasta `HeaVnz913`.
+- Traducidas las cadenas de misiones tribales de los **Vanu Vanu**, los **gnath** y los
+  **moguris** de *Heavensward*.
+- Completado el lote de subtítulos de cinemáticas de *Heavensward* iniciado en v0.3.1:
+  **17 hojas y 2.536 filas** de `VoiceMan 03000-03501`, ya sin filas pendientes de revisión.
+- Añadidos diálogos regionales y de NPC de Ishgard, Coerthas, Dravania, Idíllshire, Mar de Nubes
+  y la Diadema, además de cazas, Firmamento, Bozja, trovadores errantes, entregas personalizadas e
+  Isla Santuario.
+- Nuevos barridos de calidad y coherencia del corpus: tratamientos de personajes, género,
+  terminología, puntuación y payloads SeString revisados junto con cada lote.
+
 ## v0.3.2
 
 - Corregido el crash al abrir «Cambiar de Mundo» desde un aetheryte. El serializador SeString ahora

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ traducibles exactas.
 
 | Métrica | Valor | Avance |
 | --- | ---: | --- |
-| Avance total por líneas | 516.881/808.997 (63,9%) | ![63,9%](https://geps.dev/progress/63.9?barColor=f1c232) |
-| Hojas OK | 2.945/6.986 (42,2%) | ![42,2%](https://geps.dev/progress/42.2?barColor=f0883e) |
+| Avance total por líneas | 534.529/808.960 (66,1%) | ![66,1%](https://geps.dev/progress/66.1?barColor=f1c232) |
+| Hojas OK | 3.490/6.986 (50,0%) | ![50,0%](https://geps.dev/progress/50?barColor=f0883e) |
 
 El desglose por expansión agrupa misiones, cinemáticas y conversaciones con NPC. La interfaz, los
 objetos, el combate, los sistemas y el contenido narrativo que abarca varias expansiones se reúnen
@@ -34,13 +34,13 @@ en **Elementos comunes**, sin contarlos de nuevo en cada expansión.
 | Icono | Contenido | Líneas traducidas | Avance |
 | :---: | --- | ---: | --- |
 | <img src="docs/assets/arr-icon.png" alt="A Realm Reborn" width="40"> | **A Realm Reborn** | 38.906/38.906 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| <img src="docs/assets/hw-icon.png" alt="Heavensward" width="40"> | **Heavensward** | 4.781/25.311 (18,9%) | ![18,9%](https://geps.dev/progress/18.9?barColor=da3633) |
+| <img src="docs/assets/hw-icon.png" alt="Heavensward" width="40"> | **Heavensward** | 19.907/25.274 (78,5%) | ![78,5%](https://geps.dev/progress/78.5?barColor=7ee787) |
 | <img src="docs/assets/stb-icon.png" alt="Stormblood" width="40"> | **Stormblood** | 2/31.692 (0,0%) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
 | <img src="docs/assets/shb-icon.png" alt="Shadowbringers" width="40"> | **Shadowbringers** | 28/44.274 (0,1%) | ![0,1%](https://geps.dev/progress/0.1?barColor=da3633) |
 | <img src="docs/assets/ew-icon.png" alt="Endwalker" width="40"> | **Endwalker** | 21/47.170 (0,0%) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
 | <img src="docs/assets/dt-icon.png" alt="Dawntrail" width="40"> | **Dawntrail** | 1.174/41.536 (2,8%) | ![2,8%](https://geps.dev/progress/2.8?barColor=da3633) |
 | <img src="docs/assets/ec-icon.png" alt="Evercold" width="40"> | **Evercold** | — (progreso desconocido) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
-| — | **Elementos comunes** | 471.969/580.108 (81,4%) | ![81,4%](https://geps.dev/progress/81.4?barColor=7ee787) |
+| — | **Elementos comunes** | 474.491/580.108 (81,8%) | ![81,8%](https://geps.dev/progress/81.8?barColor=7ee787) |
 
 Evercold todavía no se ha publicado. Se muestra al 0 % hasta que exista contenido con el que medir
 su progreso real.

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12d81d87f66ca1dfeae49a71f8bd843d731b725871bc89af15eb7ad1a031c285
-size 19436615
+oid sha256:bb65b30004ab20a869cfe6e6aa5aa1655ca0f3c96fe3e9b7ccc736bcc5f9c662
+size 20914285

--- a/docs/evolucion-v0.3.0/PLAN.md
+++ b/docs/evolucion-v0.3.0/PLAN.md
@@ -233,7 +233,7 @@ Versiones verificadas para esta rama:
 
 | Componente | Versión |
 | --- | --- |
-| SDK .NET | `10.0.302` (`latestFeature`) |
+| SDK .NET | `10.0.302` (`disable`) |
 | Avalonia | `12.1.1` |
 | CommunityToolkit.Mvvm | `8.4.2` |
 | Markdig | `1.3.2` |

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.302",
-    "rollForward": "latestFeature"
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
## v0.3.3

- Actualizado el corpus con **17.648 líneas nuevas aprobadas** y **545 hojas completadas**. El
  progreso global alcanza **534.529/808.960 líneas traducibles (66,1 %)** y
  **3.490/6.986 hojas completadas (50,0 %)**.
- Gran avance de *Heavensward*: pasa del **18,9 % al 78,5 %**, con
  **19.907/25.274 líneas traducidas**.
- Traducidos amplios bloques de la historia principal de *Heavensward* (`HeaVna` y `HeaVnz`),
  incluido el avance parcial del lote actual hasta `HeaVnz913`.
- Traducidas las cadenas de misiones tribales de los **Vanu Vanu**, los **gnath** y los
  **moguris** de *Heavensward*.
- Completado el lote de subtítulos de cinemáticas de *Heavensward* iniciado en v0.3.1:
  **17 hojas y 2.536 filas** de `VoiceMan 03000-03501`, ya sin filas pendientes de revisión.
- Añadidos diálogos regionales y de NPC de Ishgard, Coerthas, Dravania, Idíllshire, Mar de Nubes
  y la Diadema, además de cazas, Firmamento, Bozja, trovadores errantes, entregas personalizadas e
  Isla Santuario.
- Nuevos barridos de calidad y coherencia del corpus: tratamientos de personajes, género,
  terminología, puntuación y payloads SeString revisados junto con cada lote.
