### PR TITLE
v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Resumen de todos los cambios relevantes del proyecto.
 
+## v0.4.1
+
+- Actualizado el corte del corpus a **567.505/814.328 líneas traducibles (69,7%)** y
+  **4.157/6.988 hojas completadas (59,5%)**. El recuento incorpora dos hojas que estaban fuera
+  del seguimiento por dominio: `CharaMakeName` y `KTGTypeWordTextData`.
+- *Stormblood* sube al **56,3 %**: **17.854/31.689 líneas traducidas**, frente a las
+  13.112 de v0.4.0.
+- Cerrados tres nuevos lotes de historia principal de *Stormblood* (`quest-stmbda-msq-002`,
+  `-003` y `-004`): **135 hojas** de guion; también se completa un lote de **12 hojas** de
+  eventos estacionales.
+- Revisadas las últimas filas pendientes de validación y corregido el texto de un objeto de misión:
+  «registro muy desgastado».
+- Corregidas las cifras internas de cinemáticas y conversaciones personalizadas para que cada
+  expansión muestre su avance real.
+
 ## v0.4.0
 
 - *Stormblood* entra en juego: la expansión pasa del **0,0 % al 41,4 %**, con

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ Resumen de todos los cambios relevantes del proyecto.
   del seguimiento por dominio: `CharaMakeName` y `KTGTypeWordTextData`.
 - *Stormblood* sube al **56,3 %**: **17.854/31.689 líneas traducidas**, frente a las
   13.112 de v0.4.0.
-- Cerrados tres nuevos lotes de historia principal de *Stormblood* (`quest-stmbda-msq-002`,
-  `-003` y `-004`): **135 hojas** de guion; también se completa un lote de **12 hojas** de
+- Cerrados tres nuevos lotes de historia principal de *Stormblood* (`quest-stmbda-msq-002`, `-003` y `-004`):
+  **135 hojas** de guion; también se completa un lote de **12 hojas** de
   eventos estacionales.
 - Revisadas las últimas filas pendientes de validación y corregido el texto de un objeto de misión:
   «registro muy desgastado».
-- Corregidas las cifras internas de cinemáticas y conversaciones personalizadas para que cada
-  expansión muestre su avance real.
+- Traducidas algunas cosas que quedaron pendientes del evento de la Verbena de este año (las conversaciones con las Pregoneras)
 
 ## v0.4.0
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ traducibles exactas.
 
 | Métrica | Valor | Avance |
 | --- | ---: | --- |
-| Avance total por líneas | 559.353/808.958 (69,1%) | ![69,1%](https://geps.dev/progress/69.1?barColor=f1c232) |
-| Hojas OK | 3.989/6.986 (57,1%) | ![57,1%](https://geps.dev/progress/57.1?barColor=f0883e) |
+| Avance total por líneas | 567.505/814.328 (69,7%) | ![69,7%](https://geps.dev/progress/69.7?barColor=f1c232) |
+| Hojas OK | 4.157/6.988 (59,5%) | ![59,5%](https://geps.dev/progress/59.5?barColor=f0883e) |
 
 El desglose por expansión agrupa misiones, cinemáticas y conversaciones con NPC. La interfaz, los
 objetos, el combate, los sistemas y el contenido narrativo que abarca varias expansiones se reúnen
@@ -35,12 +35,12 @@ en **Elementos comunes**, sin contarlos de nuevo en cada expansión.
 | :---: | --- | ---: | --- |
 | <img src="docs/assets/arr-icon.png" alt="A Realm Reborn" width="40"> | **A Realm Reborn** | 38.906/38.906 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
 | <img src="docs/assets/hw-icon.png" alt="Heavensward" width="40"> | **Heavensward** | 25.274/25.274 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| <img src="docs/assets/stb-icon.png" alt="Stormblood" width="40"> | **Stormblood** | 13.112/31.689 (41,4%) | ![41,4%](https://geps.dev/progress/41.4?barColor=f0883e) |
+| <img src="docs/assets/stb-icon.png" alt="Stormblood" width="40"> | **Stormblood** | 17.854/31.689 (56,3%) | ![56,3%](https://geps.dev/progress/56.3?barColor=f0883e) |
 | <img src="docs/assets/shb-icon.png" alt="Shadowbringers" width="40"> | **Shadowbringers** | 28/44.274 (0,1%) | ![0,1%](https://geps.dev/progress/0.1?barColor=da3633) |
 | <img src="docs/assets/ew-icon.png" alt="Endwalker" width="40"> | **Endwalker** | 22/47.170 (0,0%) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
 | <img src="docs/assets/dt-icon.png" alt="Dawntrail" width="40"> | **Dawntrail** | 1.176/41.538 (2,8%) | ![2,8%](https://geps.dev/progress/2.8?barColor=da3633) |
 | <img src="docs/assets/ec-icon.png" alt="Evercold" width="40"> | **Evercold** | — (progreso desconocido) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
-| — | **Elementos comunes** | 480.835/580.107 (82,9%) | ![82,9%](https://geps.dev/progress/82.9?barColor=7ee787) |
+| — | **Elementos comunes** | 484.245/585.477 (82,7%) | ![82,7%](https://geps.dev/progress/82.7?barColor=7ee787) |
 
 Evercold todavía no se ha publicado. Se muestra al 0 % hasta que exista contenido con el que medir
 su progreso real.

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5599910b841ed11c739736566397f02febefab64b69bee20ad067d30f705892c
-size 22807014
+oid sha256:8a3a1162ead4a96f38c459760b8706fedb12b10470b9e9ee630e885beba7fc39
+size 23270319


### PR DESCRIPTION
## v0.4.1

- Actualizado el corte del corpus a **567.505/814.328 líneas traducibles (69,7%)** y **4.157/6.988 hojas completadas (59,5%)**. El recuento incorpora dos hojas que estaban fuera del seguimiento por dominio: `CharaMakeName` y `KTGTypeWordTextData`.
- *Stormblood* sube al **56,3 %**: **17.854/31.689 líneas traducidas**, frente a las 13.112 de v0.4.0.
- Cerrados tres nuevos lotes de historia principal de *Stormblood* (`quest-stmbda-msq-002`, `-003` y `-004`):
  **135 hojas** de guion; también se completa un lote de **12 hojas** de eventos estacionales.
- Revisadas las últimas filas pendientes de validación y corregido el texto de un objeto de misión: «registro muy desgastado».
- Traducidas algunas cosas que quedaron pendientes del evento de la Verbena de este año (las conversaciones con las Pregoneras)