### PR TITLE
Refactors CI/CD workflows with dedicated scripts

### DIFF
--- a/.github/scripts/ci/publish-native.sh
+++ b/.github/scripts/ci/publish-native.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <rid> <external-translations>" >&2
+  exit 2
+fi
+
+rid="$1"
+external_translations="$2"
+project="src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj"
+
+dotnet restore "$project" --locked-mode
+dotnet publish "$project" \
+  -c Release \
+  -r "$rid" \
+  --self-contained \
+  --no-restore \
+  -p:PublishSingleFile=true \
+  -p:IncludeNativeLibrariesForSelfExtract=true \
+  -p:ExternalTranslations="$external_translations" \
+  -o "publish/$rid"

--- a/.github/scripts/ci/smoke-unix.sh
+++ b/.github/scripts/ci/smoke-unix.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rid>" >&2
+  exit 2
+fi
+
+rid="$1"
+app="$GITHUB_WORKSPACE/publish/$rid/FFXIVSpanishPatcher"
+log="$RUNNER_TEMP/FFXIVSpanishPatcher-smoke.log"
+
+chmod +x "$app"
+
+case "$rid" in
+  linux-x64)
+    xvfb-run -a "$app" >"$log" 2>&1 &
+    error_message="FFXIVSpanishPatcher exited during Linux smoke test."
+    ;;
+  osx-arm64)
+    "$app" >"$log" 2>&1 &
+    error_message="FFXIVSpanishPatcher exited during macOS smoke test."
+    ;;
+  *)
+    echo "Unsupported Unix smoke RID: $rid" >&2
+    exit 2
+    ;;
+esac
+
+app_pid=$!
+sleep 10
+if ! kill -0 "$app_pid" 2>/dev/null; then
+  cat "$log"
+  wait "$app_pid" || true
+  echo "$error_message" >&2
+  exit 1
+fi
+
+kill "$app_pid"
+wait "$app_pid" || true

--- a/.github/scripts/ci/smoke-windows.ps1
+++ b/.github/scripts/ci/smoke-windows.ps1
@@ -1,0 +1,12 @@
+$stdout = Join-Path $env:RUNNER_TEMP 'FFXIVSpanishPatcher-smoke-stdout.log'
+$stderr = Join-Path $env:RUNNER_TEMP 'FFXIVSpanishPatcher-smoke-stderr.log'
+$app = Join-Path $env:GITHUB_WORKSPACE 'publish/win-x64/FFXIVSpanishPatcher.exe'
+$process = Start-Process -FilePath $app -RedirectStandardOutput $stdout -RedirectStandardError $stderr -PassThru
+
+Start-Sleep -Seconds 10
+if ($process.HasExited) {
+    Get-Content $stdout, $stderr -ErrorAction SilentlyContinue
+    throw "FFXIVSpanishPatcher exited during Windows smoke test with code $($process.ExitCode)."
+}
+
+Stop-Process -Id $process.Id -Force

--- a/.github/scripts/release/package-unix.sh
+++ b/.github/scripts/release/package-unix.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version> <rid>" >&2
+  exit 2
+fi
+
+version="$1"
+rid="$2"
+out="publish/$rid"
+asset="FFXIVSpanishPatcher-$version-$rid.zip"
+
+rm -f "$out"/*.pdb
+
+if [[ "$rid" == osx-* ]]; then
+  # Build a proper bundle so Finder and the Dock show the icon and application name.
+  app="FFXIVSpanishPatcher.app"
+  rm -rf "$app"
+  mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+  cp "$out/FFXIVSpanishPatcher" "$app/Contents/MacOS/FFXIVSpanishPatcher"
+  chmod +x "$app/Contents/MacOS/FFXIVSpanishPatcher"
+  cp src/FFXIVSpanishPatcher.App/Assets/icon.icns "$app/Contents/Resources/icon.icns"
+  sed "s/__VERSION__/$version/g" build/macos/Info.plist > "$app/Contents/Info.plist"
+
+  # Apple Silicon requires a signature to launch. The ad-hoc signature is intentionally not notarized.
+  codesign --force --timestamp=none --sign - "$app/Contents/MacOS/FFXIVSpanishPatcher"
+  codesign --force --timestamp=none --sign - "$app"
+  codesign --verify --strict --verbose=2 "$app"
+
+  # ditto preserves both the bundle layout and its code signature.
+  ditto -c -k --keepParent "$app" "$asset"
+else
+  cp README.md "$out/README.md"
+  (cd "$out" && zip -r "../../$asset" .)
+fi
+
+if command -v sha256sum >/dev/null; then
+  sha256sum "$asset" > "$asset.sha256"
+else
+  shasum -a 256 "$asset" > "$asset.sha256"
+fi

--- a/.github/scripts/release/package-windows.sh
+++ b/.github/scripts/release/package-windows.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 2
+fi
+
+version="$1"
+out="publish/win-x64"
+asset="FFXIVSpanishPatcher-$version-win-x64.zip"
+
+rm -f "$out"/*.pdb
+cp README.md "$out/README.md"
+(cd "$out" && zip -r "../../$asset" .)
+sha256sum "$asset" > "$asset.sha256"

--- a/.github/scripts/release/prepare-nexus-description.sh
+++ b/.github/scripts/release/prepare-nexus-description.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <version> <rid> <repository>" >&2
+  exit 2
+fi
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+version="$1"
+rid="$2"
+repository="$3"
+
+case "$rid" in
+  win-x64)
+    description="Versión $version para Windows 11. Si la descarga aún no está disponible en Nexus (validación manual pendiente), puedes bajarla ya desde GitHub: https://github.com/$repository/releases/latest"
+    ;;
+  linux-x64)
+    description="Versión $version para Linux (x64)"
+    ;;
+  osx-arm64)
+    description="Versión $version para macOS Apple Silicon"
+    ;;
+  *)
+    echo "::error::RID no soportado: $rid"
+    exit 1
+    ;;
+esac
+
+echo "description=$description" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/release/publish-native.sh
+++ b/.github/scripts/release/publish-native.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "Usage: $0 <rid> <external-translations> <version> <tag> <repository>" >&2
+  exit 2
+fi
+
+rid="$1"
+external_translations="$2"
+version="$3"
+tag="$4"
+repository="$5"
+project="src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj"
+
+dotnet restore "$project" --locked-mode
+dotnet publish "$project" \
+  -c Release \
+  -r "$rid" \
+  --self-contained \
+  --no-restore \
+  -p:PublishSingleFile=true \
+  -p:IncludeNativeLibrariesForSelfExtract=true \
+  -p:ExternalTranslations="$external_translations" \
+  -p:Version="$version" \
+  -p:InformationalVersion="$tag" \
+  -p:AssemblyVersion="$version.0" \
+  -p:FileVersion="$version.0" \
+  -p:RepositorySlug="$repository" \
+  -p:LatestReleaseApiUrl="https://api.github.com/repos/$repository/releases/latest" \
+  -p:LatestReleasePageUrl="https://github.com/$repository/releases/latest" \
+  -o "publish/$rid"

--- a/.github/scripts/release/self-sign-windows.sh
+++ b/.github/scripts/release/self-sign-windows.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${WINDOWS_SELF_SIGNING_PFX_BASE64:-}" || -z "${WINDOWS_SELF_SIGNING_PFX_PASSWORD:-}" ]]; then
+  echo "::warning::Windows self-signing skipped: configure WINDOWS_SELF_SIGNING_PFX_BASE64 and WINDOWS_SELF_SIGNING_PFX_PASSWORD."
+  exit 0
+fi
+
+cert_dir="$(mktemp -d)"
+trap 'rm -rf "$cert_dir"' EXIT
+pfx="$cert_dir/FFXIVSpanishPatcher-self-signed.pfx"
+cert="$cert_dir/FFXIVSpanishPatcher-self-signed.pem"
+exe="publish/win-x64/FFXIVSpanishPatcher.exe"
+
+printf '%s' "$WINDOWS_SELF_SIGNING_PFX_BASE64" | base64 --decode > "$pfx"
+openssl pkcs12 -in "$pfx" -clcerts -nokeys \
+  -passin "pass:$WINDOWS_SELF_SIGNING_PFX_PASSWORD" -out "$cert"
+
+expected_fingerprint="$(openssl x509 \
+  -in docs/security/FFXIVSpanishPatcher-self-signed.pem \
+  -noout -fingerprint -sha256)"
+actual_fingerprint="$(openssl x509 -in "$cert" -noout -fingerprint -sha256)"
+if [[ "$actual_fingerprint" != "$expected_fingerprint" ]]; then
+  echo "::error::Windows signing certificate does not match documented public certificate."
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install --yes osslsigncode
+osslsigncode sign \
+  -pkcs12 "$pfx" \
+  -pass "$WINDOWS_SELF_SIGNING_PFX_PASSWORD" \
+  -h sha256 \
+  -n "FFXIVSpanish Patcher" \
+  -i "https://ffxivspanish.carrd.co/" \
+  -in "$exe" \
+  -out "$exe.signed"
+mv "$exe.signed" "$exe"
+osslsigncode verify -in "$exe" -CAfile "$cert"

--- a/.github/scripts/release/validate-tag.sh
+++ b/.github/scripts/release/validate-tag.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+tag="$GITHUB_REF_NAME"
+if [[ ! "$tag" =~ ^v(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})$ ]]; then
+  echo "::error::Release tags must match vX.Y.Z, with each number from 0 to 999."
+  exit 1
+fi
+
+echo "tag=$tag" >> "$GITHUB_OUTPUT"
+echo "version=${tag#v}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,71 +55,23 @@ jobs:
           global-json-file: global.json
 
       - name: Publish ${{ matrix.rid }}
-        run: >
-          dotnet restore src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj
-          --locked-mode
-          &&
-          dotnet publish src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj
-          -c Release -r ${{ matrix.rid }} --self-contained --no-restore
-          -p:PublishSingleFile=true
-          -p:IncludeNativeLibrariesForSelfExtract=true
-          -p:ExternalTranslations=${{ matrix.external_translations }}
-          -o publish/${{ matrix.rid }}
+        shell: bash
+        run: ./.github/scripts/ci/publish-native.sh "${{ matrix.rid }}" "${{ matrix.external_translations }}"
 
       - name: Smoke Windows executable
         if: runner.os == 'Windows'
         shell: pwsh
-        run: |
-          $stdout = Join-Path $env:RUNNER_TEMP 'FFXIVSpanishPatcher-smoke-stdout.log'
-          $stderr = Join-Path $env:RUNNER_TEMP 'FFXIVSpanishPatcher-smoke-stderr.log'
-          $app = Join-Path $env:GITHUB_WORKSPACE 'publish/win-x64/FFXIVSpanishPatcher.exe'
-          $process = Start-Process -FilePath $app -RedirectStandardOutput $stdout -RedirectStandardError $stderr -PassThru
-          Start-Sleep -Seconds 10
-          if ($process.HasExited) {
-            Get-Content $stdout, $stderr -ErrorAction SilentlyContinue
-            throw "FFXIVSpanishPatcher exited during Windows smoke test with code $($process.ExitCode)."
-          }
-          Stop-Process -Id $process.Id -Force
+        run: ./.github/scripts/ci/smoke-windows.ps1
 
       - name: Smoke macOS executable
         if: runner.os == 'macOS'
         shell: bash
-        run: |
-          set -euo pipefail
-          app="$GITHUB_WORKSPACE/publish/osx-arm64/FFXIVSpanishPatcher"
-          log="$RUNNER_TEMP/FFXIVSpanishPatcher-smoke.log"
-          chmod +x "$app"
-          "$app" >"$log" 2>&1 &
-          app_pid=$!
-          sleep 10
-          if ! kill -0 "$app_pid" 2>/dev/null; then
-            cat "$log"
-            wait "$app_pid" || true
-            echo "FFXIVSpanishPatcher exited during macOS smoke test." >&2
-            exit 1
-          fi
-          kill "$app_pid"
-          wait "$app_pid" || true
+        run: ./.github/scripts/ci/smoke-unix.sh osx-arm64
 
       - name: Smoke Linux executable
         if: runner.os == 'Linux'
         shell: bash
-        run: |
-          set -euo pipefail
-          app="$GITHUB_WORKSPACE/publish/linux-x64/FFXIVSpanishPatcher"
-          log="$RUNNER_TEMP/FFXIVSpanishPatcher-smoke.log"
-          chmod +x "$app"
-          xvfb-run -a "$app" >"$log" 2>&1 &
-          app_pid=$!
-          sleep 10
-          if ! kill -0 "$app_pid" 2>/dev/null; then
-            cat "$log"
-            wait "$app_pid" || true
-            echo "FFXIVSpanishPatcher exited during Linux smoke test." >&2
-            exit 1
-          fi
-          kill "$app_pid"
-          wait "$app_pid" || true
+        run: ./.github/scripts/ci/smoke-unix.sh linux-x64
 
       - name: Upload smoke log
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,17 @@ permissions:
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.version.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Validate tag and derive version
         id: version
-        run: |
-          set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})$ ]]; then
-            echo "::error::Release tags must match vX.Y.Z, with each number from 0 to 999."
-            exit 1
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+        run: ./.github/scripts/release/validate-tag.sh
 
   publish:
     needs: validate-tag
@@ -58,23 +54,13 @@ jobs:
 
       - name: Publish ${{ matrix.rid }}
         shell: bash
-        run: >
-          dotnet restore src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj
-          --locked-mode
-          &&
-          dotnet publish src/FFXIVSpanishPatcher.App/FFXIVSpanishPatcher.App.csproj
-          -c Release -r ${{ matrix.rid }} --self-contained --no-restore
-          -p:PublishSingleFile=true
-          -p:IncludeNativeLibrariesForSelfExtract=true
-          -p:ExternalTranslations=${{ matrix.external_translations }}
-          -p:Version=${{ needs.validate-tag.outputs.version }}
-          -p:InformationalVersion=${{ needs.validate-tag.outputs.tag }}
-          -p:AssemblyVersion=${{ needs.validate-tag.outputs.version }}.0
-          -p:FileVersion=${{ needs.validate-tag.outputs.version }}.0
-          -p:RepositorySlug=${{ github.repository }}
-          -p:LatestReleaseApiUrl=https://api.github.com/repos/${{ github.repository }}/releases/latest
-          -p:LatestReleasePageUrl=https://github.com/${{ github.repository }}/releases/latest
-          -o publish/${{ matrix.rid }}
+        run: >-
+          ./.github/scripts/release/publish-native.sh
+          "${{ matrix.rid }}"
+          "${{ matrix.external_translations }}"
+          "${{ needs.validate-tag.outputs.version }}"
+          "${{ needs.validate-tag.outputs.tag }}"
+          "${{ github.repository }}"
 
       # Keep the Windows publish native, then pass it to a Linux job for non-interactive signing.
       - name: Upload unsigned Windows publish
@@ -89,38 +75,10 @@ jobs:
 
       - name: Package Linux or macOS
         if: matrix.rid != 'win-x64'
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.validate-tag.outputs.version }}"
-          RID="${{ matrix.rid }}"
-          OUT="publish/$RID"
-          ASSET="FFXIVSpanishPatcher-$VERSION-$RID.zip"
-          rm -f "$OUT"/*.pdb
-          if [[ "$RID" == osx-* ]]; then
-            # Assemble a proper .app bundle so macOS shows the icon (Dock/Finder) and a real app name.
-            APP="FFXIVSpanishPatcher.app"
-            rm -rf "$APP"
-            mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
-            cp "$OUT/FFXIVSpanishPatcher" "$APP/Contents/MacOS/FFXIVSpanishPatcher"
-            chmod +x "$APP/Contents/MacOS/FFXIVSpanishPatcher"
-            cp src/FFXIVSpanishPatcher.App/Assets/icon.icns "$APP/Contents/Resources/icon.icns"
-            sed "s/__VERSION__/$VERSION/g" build/macos/Info.plist > "$APP/Contents/Info.plist"
-            # Ad-hoc sign (inner Mach-O, then the bundle). Required for arm64 to launch and removes
-            # the "is damaged" Gatekeeper error. Not notarized: users still "Open Anyway" once.
-            codesign --force --timestamp=none --sign - "$APP/Contents/MacOS/FFXIVSpanishPatcher"
-            codesign --force --timestamp=none --sign - "$APP"
-            codesign --verify --strict --verbose=2 "$APP"
-            # ditto is Apple's archiver; it preserves the code signature and bundle layout.
-            ditto -c -k --keepParent "$APP" "$ASSET"
-          else
-            cp README.md "$OUT/README.md"
-            ( cd "$OUT" && zip -r "../../$ASSET" . )
-          fi
-          if command -v sha256sum >/dev/null; then
-            sha256sum "$ASSET" > "$ASSET.sha256"
-          else
-            shasum -a 256 "$ASSET" > "$ASSET.sha256"
-          fi
+        run: >-
+          ./.github/scripts/release/package-unix.sh
+          "${{ needs.validate-tag.outputs.version }}"
+          "${{ matrix.rid }}"
 
       - name: Attach to release
         if: matrix.rid != 'win-x64'
@@ -139,27 +97,11 @@ jobs:
         id: nexus-description
         if: matrix.rid != 'win-x64' && matrix.nexus_file_id != ''
         shell: bash
-        run: |
-          VERSION="${{ needs.validate-tag.outputs.version }}"
-          RID="${{ matrix.rid }}"
-
-          case "$RID" in
-            win-x64)
-              DESCRIPTION="Versión $VERSION para Windows 11. Si la descarga aún no está disponible en Nexus (validación manual pendiente), puedes bajarla ya desde GitHub: https://github.com/${{ github.repository }}/releases/latest"
-              ;;
-            linux-x64)
-              DESCRIPTION="Versión $VERSION para Linux (x64)"
-              ;;
-            osx-arm64)
-              DESCRIPTION="Versión $VERSION para macOS Apple Silicon"
-              ;;
-            *)
-              echo "::error::RID no soportado: $RID"
-              exit 1
-              ;;
-          esac
-
-          echo "description=$DESCRIPTION" >> "$GITHUB_OUTPUT"
+        run: >-
+          ./.github/scripts/release/prepare-nexus-description.sh
+          "${{ needs.validate-tag.outputs.version }}"
+          "${{ matrix.rid }}"
+          "${{ github.repository }}"
 
       - name: Upload to Nexus Mods
         if: matrix.rid != 'win-x64' && matrix.nexus_file_id != ''
@@ -194,56 +136,10 @@ jobs:
         env:
           WINDOWS_SELF_SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_SELF_SIGNING_PFX_BASE64 }}
           WINDOWS_SELF_SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_SELF_SIGNING_PFX_PASSWORD }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$WINDOWS_SELF_SIGNING_PFX_BASE64" || -z "$WINDOWS_SELF_SIGNING_PFX_PASSWORD" ]]; then
-            echo "::warning::Windows self-signing skipped: configure WINDOWS_SELF_SIGNING_PFX_BASE64 and WINDOWS_SELF_SIGNING_PFX_PASSWORD."
-            exit 0
-          fi
-
-          CERT_DIR="$(mktemp -d)"
-          trap 'rm -rf "$CERT_DIR"' EXIT
-          PFX="$CERT_DIR/FFXIVSpanishPatcher-self-signed.pfx"
-          CERT="$CERT_DIR/FFXIVSpanishPatcher-self-signed.pem"
-          EXE="publish/win-x64/FFXIVSpanishPatcher.exe"
-
-          printf '%s' "$WINDOWS_SELF_SIGNING_PFX_BASE64" | base64 --decode > "$PFX"
-          openssl pkcs12 -in "$PFX" -clcerts -nokeys \
-            -passin "pass:$WINDOWS_SELF_SIGNING_PFX_PASSWORD" -out "$CERT"
-
-          EXPECTED_FINGERPRINT="$(openssl x509 \
-            -in docs/security/FFXIVSpanishPatcher-self-signed.pem \
-            -noout -fingerprint -sha256)"
-          ACTUAL_FINGERPRINT="$(openssl x509 -in "$CERT" -noout -fingerprint -sha256)"
-          if [[ "$ACTUAL_FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]]; then
-            echo "::error::Windows signing certificate does not match documented public certificate."
-            exit 1
-          fi
-
-          sudo apt-get update
-          sudo apt-get install --yes osslsigncode
-          osslsigncode sign \
-            -pkcs12 "$PFX" \
-            -pass "$WINDOWS_SELF_SIGNING_PFX_PASSWORD" \
-            -h sha256 \
-            -n "FFXIVSpanish Patcher" \
-            -i "https://ffxivspanish.carrd.co/" \
-            -in "$EXE" \
-            -out "$EXE.signed"
-          mv "$EXE.signed" "$EXE"
-          osslsigncode verify -in "$EXE" -CAfile "$CERT"
+        run: ./.github/scripts/release/self-sign-windows.sh
 
       - name: Package Windows
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.validate-tag.outputs.version }}"
-          OUT="publish/win-x64"
-          ASSET="FFXIVSpanishPatcher-$VERSION-win-x64.zip"
-
-          rm -f "$OUT"/*.pdb
-          cp README.md "$OUT/README.md"
-          ( cd "$OUT" && zip -r "../../$ASSET" . )
-          sha256sum "$ASSET" > "$ASSET.sha256"
+        run: ./.github/scripts/release/package-windows.sh "${{ needs.validate-tag.outputs.version }}"
 
       - name: Attach Windows to release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2


### PR DESCRIPTION
Extracts complex inline commands from GitHub Actions into reusable scripts.

- Enhances workflow readability and maintainability by centralizing logic for native publishing, smoke testing, artifact packaging, and signing across Windows, macOS, and Linux.
- Improves code quality by breaking down large, inline blocks into manageable, dedicated script files.
- Explicitly sets `contents: read` permissions for the CI workflow for improved security and best practices.