### PR TITLE
v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Resumen de todos los cambios relevantes del proyecto.
 
+## v0.4.2
+
+- ***Stormblood* al 100 %**💪🥳🎉⚔️: **31.689/31.689 líneas traducidas** , frente a las 17.854 (56,3 %) de
+  v0.4.1.
+- Cerrado el tramo final de la historia principal de *Stormblood* con tres lotes:
+  `quest-stmbda-msq-005` (**63 hojas**), `-006` (**114 hojas**) y `-007` (**92 hojas**). Cubren
+  desde la Estepa de Azim y Reunión hasta Ala Mhigo, Rhalgr y los epílogos de parche 4.x.
+- Completadas las **59 hojas** de las tribus **ananta** y **namazu** de *Stormblood*
+  (`quest-ananta-namazu-001`, **2.111 filas**).
+- Traducidas las **8 hojas** de `custom-cts-009-001` (Palacio de los Muertos 4, tintes, gremio de
+  aventureros).
+- Localizada la hoja **`Hud`** de la interfaz (gracias a Ophelia Manito por la pequeña contribución)
+- Revisada la calidad de la traducción y arreglo de varios fallos de traducción realizados a lo largo de las versiones 0.4.X
+- Recuento global recalculado desde el corpus: **588.999/809.234 líneas traducibles (72,8 %)** y
+  **4.604/6.987 hojas completadas (65,9 %)**. El denominador baja respecto a v0.4.1 porque la cifra
+  anterior no cuadraba con la suma de los dominios; ahora ambas coinciden.
+
 ## v0.4.1
 
 - Actualizado el corte del corpus a **567.505/814.328 líneas traducibles (69,7%)** y

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ traducibles exactas.
 
 | Métrica | Valor | Avance |
 | --- | ---: | --- |
-| Avance total por líneas | 567.505/814.328 (69,7%) | ![69,7%](https://geps.dev/progress/69.7?barColor=f1c232) |
-| Hojas OK | 4.157/6.988 (59,5%) | ![59,5%](https://geps.dev/progress/59.5?barColor=f0883e) |
+| Avance total por líneas | 588.999/809.234 (72,8%) | ![72,8%](https://geps.dev/progress/72.8?barColor=7ee787) |
+| Hojas OK | 4.604/6.987 (65,9%) | ![65,9%](https://geps.dev/progress/65.9?barColor=f0883e) |
 
 El desglose por expansión agrupa misiones, cinemáticas y conversaciones con NPC. La interfaz, los
 objetos, el combate, los sistemas y el contenido narrativo que abarca varias expansiones se reúnen
@@ -35,12 +35,12 @@ en **Elementos comunes**, sin contarlos de nuevo en cada expansión.
 | :---: | --- | ---: | --- |
 | <img src="docs/assets/arr-icon.png" alt="A Realm Reborn" width="40"> | **A Realm Reborn** | 38.906/38.906 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
 | <img src="docs/assets/hw-icon.png" alt="Heavensward" width="40"> | **Heavensward** | 25.274/25.274 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| <img src="docs/assets/stb-icon.png" alt="Stormblood" width="40"> | **Stormblood** | 17.854/31.689 (56,3%) | ![56,3%](https://geps.dev/progress/56.3?barColor=f0883e) |
+| <img src="docs/assets/stb-icon.png" alt="Stormblood" width="40"> | **Stormblood** | 31.689/31.689 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
 | <img src="docs/assets/shb-icon.png" alt="Shadowbringers" width="40"> | **Shadowbringers** | 28/44.274 (0,1%) | ![0,1%](https://geps.dev/progress/0.1?barColor=da3633) |
 | <img src="docs/assets/ew-icon.png" alt="Endwalker" width="40"> | **Endwalker** | 22/47.170 (0,0%) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
 | <img src="docs/assets/dt-icon.png" alt="Dawntrail" width="40"> | **Dawntrail** | 1.176/41.538 (2,8%) | ![2,8%](https://geps.dev/progress/2.8?barColor=da3633) |
 | <img src="docs/assets/ec-icon.png" alt="Evercold" width="40"> | **Evercold** | — (progreso desconocido) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
-| — | **Elementos comunes** | 484.245/585.477 (82,7%) | ![82,7%](https://geps.dev/progress/82.7?barColor=7ee787) |
+| — | **Elementos comunes** | 491.904/580.383 (84,8%) | ![84,8%](https://geps.dev/progress/84.8?barColor=7ee787) |
 
 Evercold todavía no se ha publicado. Se muestra al 0 % hasta que exista contenido con el que medir
 su progreso real.

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a3a1162ead4a96f38c459760b8706fedb12b10470b9e9ee630e885beba7fc39
-size 23270319
+oid sha256:0e6f5a3b9ad1c66110ac55cf64f7e38014fd8d369ac1c922f1a8e2f9ee686968
+size 25009033


### PR DESCRIPTION
## v0.4.2

- ***Stormblood* al 100 %**💪🥳🎉⚔️: **31.689/31.689 líneas traducidas** , frente a las 17.854 (56,3 %) de v0.4.1.
- Cerrado el tramo final de la historia principal de *Stormblood* con tres lotes: `quest-stmbda-msq-005` (**63 hojas**), `-006` (**114 hojas**) y `-007` (**92 hojas**). Cubren desde la Estepa de Azim y Reunión hasta Ala Mhigo, Rhalgr y los epílogos de parche 4.x.
- Completadas las **59 hojas** de las tribus **ananta** y **namazu** de *Stormblood* (`quest-ananta-namazu-001`, **2.111 filas**).
- Traducidas las **8 hojas** de `custom-cts-009-001` (Palacio de los Muertos 4, tintes, gremio de aventureros).
- Localizada la hoja **`Hud`** de la interfaz (gracias a Ophelia Manito por la pequeña contribución)
- Revisada la calidad de la traducción y arreglo de varios fallos de traducción realizados a lo largo de las versiones 0.4.X
- Recuento global recalculado desde el corpus: **588.999/809.234 líneas traducibles (72,8 %)** y  **4.604/6.987 hojas completadas (65,9 %)**. El denominador baja respecto a v0.4.1 porque la cifra anterior no cuadraba con la suma de los dominios; ahora ambas coinciden.
