### PR TITLE
v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,41 +5,19 @@ Resumen de todos los cambios relevantes del proyecto.
 ## v0.4.3
 
 Versión centrada en la **calidad** de lo ya traducido más que en volumen nuevo: una campaña de
-revisión trilingüe (EN + FR → ES) sobre el guion existente, además de dos líneas de misiones de job
-de *Stormblood*.
+revisión trilingüe (EN + FR → ES) sobre el guion existente y corrección de errores (gracias a quienes reportaron fallos)
 
 - **Misiones de job de *Stormblood***: traducidas las líneas completas de **samurái**
   (`quest-jobsam-001`, **889 filas**) y **mago rojo** (`quest-jobrdm-001`, **1.134 filas**), en doce
   sub-lotes de nivel 50 a 70.
-- **Campaña de revisión de calidad**: **232 pasadas de QA** sobre el guion ya publicado —
-  eventos estacionales y colaboraciones, títulos de misión, conversaciones con NPC y misiones de
-  clase—, corrigiendo género, tratamiento y sentido con el francés y el alemán como anclas.
-- **Género del personaje jugador**: se abandona la neutralización forzada y el texto vuelve a
-  flexionar donde el juego lo permite. Se derogó la familia «alma \<adjetivo\>» (alma aventurera,
-  heroica, amiga, forastera) en favor de la macro de género del propio juego, y se resolvieron
-  los `lass|lad`, `miss|sir` y los epítetos deícticos («héroe/heroína de Eorzea», «forastero/a»).
-- **Tratamiento**: realineados los registros de tuteo y voseo ratificados en la entrevista de
-  terminología; corregidos los personajes que tuteaban al jugador cuando no debían.
-- **Barridos de terminología y mayúsculas**: nombres de razas y de tribus bestia pasan a minúscula
-  como sustantivos comunes (**2.895 filas**); «copy of \<obra\>» pasa a «ejemplar» (**342 campos**);
-  «Impresario» a «Empresario teatral» (**154 campos**); GP pasa a **PR**; «job» se mantiene como
-  «job»; y se unificaron topónimos, honoríficos y nombres de naves y obras con su género en español.
-- **Tipografía del guion**: la raya de apertura de diálogo lleva siempre espacio (**1.246 filas**),
-  se restauró el guion de caja que se había perdido, y se separaron los puntos suspensivos pegados.
-- **Fugas de inglés**: cerrados los títulos de obra, las listas de esencias de Bozja y el bloque de
-  estadísticas de comida que seguían en inglés dentro de textos ya traducidos.
-- **Memoria de localización**: las 179 fichas de dudas sueltas se sustituyen por una única cola de
-  barridos; se escribieron en su capa de canon las 48 decisiones de la entrevista; y se
-  reanclaron 443 citas a lemas (con 110 citas muertas eliminadas), con un nuevo *lint* que impide
-  que las referencias entre documentos vuelvan a quedarse huérfanas.
+- **Campaña exhaustiva de revisión de calidad**: Muchos cambios para enumerarlos.. pero resumiendo:
+  > Se acaba con la formulacion de "alma aventurera" y similares
+  > Revisión de flexión de género del personaje
+  > Correcciones varias
 - **Herramientas**: el validador de SeString acepta una condicional de género propia de la
   traducción junto a los payloads del original, y añade diagnóstico por multiconjunto de bytes de
   control; el detector de fugas de inglés de `BatchVerify` acota su lista de excepciones por hoja.
-- Recuento global recalculado desde el corpus: **596.958/815.173 líneas traducibles (73,2 %)** y
-  **4.627/6.987 hojas completadas (66,2 %)**, frente al 72,8 % y 65,9 % de v0.4.2. *Elementos
-  comunes* sube del **84,8 % al 85,3 %**. Las cifras de *A Realm Reborn*, *Heavensward* y
-  *Stormblood* se mueven unas pocas líneas porque el denominador se ha vuelto a medir contra el
-  cliente instalado; las tres siguen al **100 %**.
+
 
 ## v0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Resumen de todos los cambios relevantes del proyecto.
 
+## v0.4.3
+
+Versión centrada en la **calidad** de lo ya traducido más que en volumen nuevo: una campaña de
+revisión trilingüe (EN + FR → ES) sobre el guion existente, además de dos líneas de misiones de job
+de *Stormblood*.
+
+- **Misiones de job de *Stormblood***: traducidas las líneas completas de **samurái**
+  (`quest-jobsam-001`, **889 filas**) y **mago rojo** (`quest-jobrdm-001`, **1.134 filas**), en doce
+  sub-lotes de nivel 50 a 70.
+- **Campaña de revisión de calidad**: **232 pasadas de QA** sobre el guion ya publicado —
+  eventos estacionales y colaboraciones, títulos de misión, conversaciones con NPC y misiones de
+  clase—, corrigiendo género, tratamiento y sentido con el francés y el alemán como anclas.
+- **Género del personaje jugador**: se abandona la neutralización forzada y el texto vuelve a
+  flexionar donde el juego lo permite. Se derogó la familia «alma \<adjetivo\>» (alma aventurera,
+  heroica, amiga, forastera) en favor de la macro de género del propio juego, y se resolvieron
+  los `lass|lad`, `miss|sir` y los epítetos deícticos («héroe/heroína de Eorzea», «forastero/a»).
+- **Tratamiento**: realineados los registros de tuteo y voseo ratificados en la entrevista de
+  terminología; corregidos los personajes que tuteaban al jugador cuando no debían.
+- **Barridos de terminología y mayúsculas**: nombres de razas y de tribus bestia pasan a minúscula
+  como sustantivos comunes (**2.895 filas**); «copy of \<obra\>» pasa a «ejemplar» (**342 campos**);
+  «Impresario» a «Empresario teatral» (**154 campos**); GP pasa a **PR**; «job» se mantiene como
+  «job»; y se unificaron topónimos, honoríficos y nombres de naves y obras con su género en español.
+- **Tipografía del guion**: la raya de apertura de diálogo lleva siempre espacio (**1.246 filas**),
+  se restauró el guion de caja que se había perdido, y se separaron los puntos suspensivos pegados.
+- **Fugas de inglés**: cerrados los títulos de obra, las listas de esencias de Bozja y el bloque de
+  estadísticas de comida que seguían en inglés dentro de textos ya traducidos.
+- **Memoria de localización**: las 179 fichas de dudas sueltas se sustituyen por una única cola de
+  barridos; se escribieron en su capa de canon las 48 decisiones de la entrevista; y se
+  reanclaron 443 citas a lemas (con 110 citas muertas eliminadas), con un nuevo *lint* que impide
+  que las referencias entre documentos vuelvan a quedarse huérfanas.
+- **Herramientas**: el validador de SeString acepta una condicional de género propia de la
+  traducción junto a los payloads del original, y añade diagnóstico por multiconjunto de bytes de
+  control; el detector de fugas de inglés de `BatchVerify` acota su lista de excepciones por hoja.
+- Recuento global recalculado desde el corpus: **596.958/815.173 líneas traducibles (73,2 %)** y
+  **4.627/6.987 hojas completadas (66,2 %)**, frente al 72,8 % y 65,9 % de v0.4.2. *Elementos
+  comunes* sube del **84,8 % al 85,3 %**. Las cifras de *A Realm Reborn*, *Heavensward* y
+  *Stormblood* se mueven unas pocas líneas porque el denominador se ha vuelto a medir contra el
+  cliente instalado; las tres siguen al **100 %**.
+
 ## v0.4.2
 
 - ***Stormblood* al 100 %**💪🥳🎉⚔️: **31.689/31.689 líneas traducidas** , frente a las 17.854 (56,3 %) de

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ traducibles exactas.
 
 | Métrica | Valor | Avance |
 | --- | ---: | --- |
-| Avance total por líneas | 588.999/809.234 (72,8%) | ![72,8%](https://geps.dev/progress/72.8?barColor=7ee787) |
-| Hojas OK | 4.604/6.987 (65,9%) | ![65,9%](https://geps.dev/progress/65.9?barColor=f0883e) |
+| Avance total por líneas | 596.958/815.173 (73,2%) | ![73,2%](https://geps.dev/progress/73.2?barColor=7ee787) |
+| Hojas OK | 4.627/6.987 (66,2%) | ![66,2%](https://geps.dev/progress/66.2?barColor=f0883e) |
 
 El desglose por expansión agrupa misiones, cinemáticas y conversaciones con NPC. La interfaz, los
 objetos, el combate, los sistemas y el contenido narrativo que abarca varias expansiones se reúnen
@@ -33,14 +33,14 @@ en **Elementos comunes**, sin contarlos de nuevo en cada expansión.
 
 | Icono | Contenido | Líneas traducidas | Avance |
 | :---: | --- | ---: | --- |
-| <img src="docs/assets/arr-icon.png" alt="A Realm Reborn" width="40"> | **A Realm Reborn** | 38.906/38.906 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| <img src="docs/assets/hw-icon.png" alt="Heavensward" width="40"> | **Heavensward** | 25.274/25.274 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| <img src="docs/assets/stb-icon.png" alt="Stormblood" width="40"> | **Stormblood** | 31.689/31.689 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
-| <img src="docs/assets/shb-icon.png" alt="Shadowbringers" width="40"> | **Shadowbringers** | 28/44.274 (0,1%) | ![0,1%](https://geps.dev/progress/0.1?barColor=da3633) |
-| <img src="docs/assets/ew-icon.png" alt="Endwalker" width="40"> | **Endwalker** | 22/47.170 (0,0%) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
-| <img src="docs/assets/dt-icon.png" alt="Dawntrail" width="40"> | **Dawntrail** | 1.176/41.538 (2,8%) | ![2,8%](https://geps.dev/progress/2.8?barColor=da3633) |
+| <img src="docs/assets/arr-icon.png" alt="A Realm Reborn" width="40"> | **A Realm Reborn** | 38.897/38.897 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
+| <img src="docs/assets/hw-icon.png" alt="Heavensward" width="40"> | **Heavensward** | 25.268/25.268 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
+| <img src="docs/assets/stb-icon.png" alt="Stormblood" width="40"> | **Stormblood** | 31.664/31.664 (100,0%) | ![100,0%](https://geps.dev/progress/100?barColor=2ea043) |
+| <img src="docs/assets/shb-icon.png" alt="Shadowbringers" width="40"> | **Shadowbringers** | 0/44.246 (0,0%) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
+| <img src="docs/assets/ew-icon.png" alt="Endwalker" width="40"> | **Endwalker** | 2/47.150 (0,0%) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
+| <img src="docs/assets/dt-icon.png" alt="Dawntrail" width="40"> | **Dawntrail** | 1.143/41.505 (2,8%) | ![2,8%](https://geps.dev/progress/2.8?barColor=da3633) |
 | <img src="docs/assets/ec-icon.png" alt="Evercold" width="40"> | **Evercold** | — (progreso desconocido) | ![0,0%](https://geps.dev/progress/0?barColor=da3633) |
-| — | **Elementos comunes** | 491.904/580.383 (84,8%) | ![84,8%](https://geps.dev/progress/84.8?barColor=7ee787) |
+| — | **Elementos comunes** | 499.984/586.443 (85,3%) | ![85,3%](https://geps.dev/progress/85.3?barColor=7ee787) |
 
 Evercold todavía no se ha publicado. Se muestra al 0 % hasta que exista contenido con el que medir
 su progreso real.

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5458c330598cc7a44d962310edc33a8d1f6dfbfb0d16b65ba0420c35e6a26973
-size 25176155
+oid sha256:6c217b3a149db5aaab1e1c0ed428485c8416d872e9693236f49c28cce8bb59d0
+size 25226435

--- a/data/translations.dat
+++ b/data/translations.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e6f5a3b9ad1c66110ac55cf64f7e38014fd8d369ac1c922f1a8e2f9ee686968
-size 25009033
+oid sha256:5458c330598cc7a44d962310edc33a8d1f6dfbfb0d16b65ba0420c35e6a26973
+size 25176155

--- a/tests/FFXIVSpanishPatcher.Tests/ExdPatcherRegressionTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/ExdPatcherRegressionTests.cs
@@ -66,4 +66,42 @@ public sealed class ExdPatcherRegressionTests
             .Raw;
         Assert.Equal(target, SeStringTreeTokenizer.TokenizeRawText(patchedRaw));
     }
+
+    [Fact]
+    public void Patch_FieldAware_PermutedEmptyVfxAdditional_UsesItsBlankColumn()
+    {
+        // Snipe's generated member order labels these physical columns backwards: ActionText is
+        // non-empty, while VFXAdditional is an intentional empty-source write. The exact source
+        // lets the patcher identify ActionText's real column and move VFXAdditional to the blank
+        // column it vacated, instead of the empty write consuming ActionText's column (which made
+        // BOTH rows miss: 94 misses over the Snipe sheet).
+        var exd = SyntheticExd.BuildExd([(4u, new[] { string.Empty, "Observe" })], fixedSize: 8);
+        var replacements = new Dictionary<uint, IReadOnlyList<StringReplacement>>
+        {
+            [4u] =
+            [
+                new StringReplacement(string.Empty, "Texto VFX", "VFXAdditional"),
+                new StringReplacement("Observe", "Texto de acción", "ActionText"),
+            ],
+        };
+
+        // Intentionally reflects the faulty generated declaration order: physical ordinal 0 is
+        // VFXAdditional and ordinal 1 is ActionText, while the labels claim the reverse.
+        var result = ExdPatcher.Patch(
+            exd,
+            fixedDataSize: 8,
+            stringColumnOffsets: [0, 4],
+            replacements,
+            stringColumnFieldNames: ["ActionText", "VFXAdditional"]);
+
+        Assert.Equal(2, result.Applied);
+        Assert.Empty(result.Missed);
+
+        var patched = ExdRowReader.ReadRawStrings(result.Bytes, 8, [0, 4])
+            .Where(row => row.RowId == 4u)
+            .OrderBy(row => row.ColumnOrdinal)
+            .Select(row => SeStringTreeTokenizer.TokenizeRawText(row.Raw))
+            .ToArray();
+        Assert.Equal(["Texto VFX", "Texto de acción"], patched);
+    }
 }

--- a/tests/FFXIVSpanishPatcher.Tests/PlayerGenderMacroTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/PlayerGenderMacroTests.cs
@@ -52,15 +52,28 @@ public sealed class PlayerGenderMacroTests
         Assert.Empty(ManifestSeStringGate.Check([entry]));
     }
 
+    // Since upstream eca5c2789 a target-owned gender conditional is allowed on top of a
+    // payload-bearing source: the conditional is stripped before the payload multiset, order,
+    // nesting and control bytes are checked. Payload loss is still rejected - see
+    // SeStringGenderAndControlByteTests.
     [Fact]
-    public void Validator_GenderMacroOnPayloadSource_Fails()
+    public void ManifestGate_GenderMacroOnPayloadSource_Passes()
     {
-        var report = SeStringCompatibilityValidator.Validate(
+        var entry = Entry(
             "Welcome, <Num>",
             "Hola, <Num> <Gender>Guerrera<GenderElse>Guerrero<GenderEnd>");
 
-        Assert.False(report.IsCompatible);
-        Assert.Equal(SeStringViolationKind.InvalidStandardMacro, Assert.Single(report.Violations).Kind);
+        Assert.Empty(ManifestSeStringGate.Check([entry]));
+    }
+
+    [Fact]
+    public void ManifestGate_GenderMacroDroppingASourcePayload_IsUnsafe()
+    {
+        var entry = Entry("Welcome, <Num>", "Hola, <Gender>Guerrera<GenderElse>Guerrero<GenderEnd>");
+
+        var violation = Assert.Single(ManifestSeStringGate.Check([entry]));
+
+        Assert.Contains(violation.Report.Violations, v => v.Kind == SeStringViolationKind.MissingPayload);
     }
 
     private static TranslationEntry Entry(string source, string target) => new()

--- a/tests/FFXIVSpanishPatcher.Tests/SeStringGenderAndControlByteTests.cs
+++ b/tests/FFXIVSpanishPatcher.Tests/SeStringGenderAndControlByteTests.cs
@@ -1,0 +1,189 @@
+using XivSpanish.GameData;
+using Xunit;
+
+namespace FFXIVSpanishPatcher.Tests;
+
+/// <summary>
+/// Ported from upstream FFXIV-Spanish (21db9c62e control-byte multiset diagnostics, eca5c2789
+/// target-owned gender conditional alongside source payloads). The string literals carry raw
+/// control bytes on purpose - do not "clean up" this file by hand.
+/// </summary>
+public sealed class SeStringGenderAndControlByteTests
+{
+    [Fact]
+    public void LostControlBytes_Fails_NamingEveryLostByte()
+    {
+        // Doma-style gender fork whose target drops the \x05 parameter byte and the \x0c/\x12
+        // expression bytes carried between tokens.
+        var source = "Hello, <If><Raw><Run>miss<RunEnd><Run#2>sir<RunEnd#2><MacroEnd>!";
+        var target = "Hola, <If><Raw><Run>señorita<RunEnd><Run#2>señor<RunEnd#2><MacroEnd>!";
+
+        var report = SeStringCompatibilityValidator.Validate(source, target);
+
+        Assert.False(report.IsCompatible);
+        var violation = Assert.Single(report.Violations);
+        Assert.Equal(SeStringViolationKind.ControlCharMismatch, violation.Kind);
+        Assert.Contains("lost from target", violation.Message, System.StringComparison.Ordinal);
+        Assert.Contains("0x05", violation.Message, System.StringComparison.Ordinal);
+        Assert.Contains("0x0C", violation.Message, System.StringComparison.Ordinal);
+        Assert.Contains("0x12", violation.Message, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("invented in target", violation.Message, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InventedControlByte_Fails_NamingTheExtraByte()
+    {
+        var source = "A<If>xy<MacroEnd>B";
+        var target = "A<If>xy<MacroEnd>B";
+
+        var report = SeStringCompatibilityValidator.Validate(source, target);
+
+        Assert.False(report.IsCompatible);
+        var violation = Assert.Single(report.Violations);
+        Assert.Equal(SeStringViolationKind.ControlCharMismatch, violation.Kind);
+        Assert.Contains("invented in target", violation.Message, System.StringComparison.Ordinal);
+        Assert.Contains("0x03", violation.Message, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("lost from target", violation.Message, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwappedControlBytes_SameMultiset_Fails_AsReordered()
+    {
+        var source = "ABC<Num>";
+        var target = "ABC<Num>";
+
+        var report = SeStringCompatibilityValidator.Validate(source, target);
+
+        Assert.False(report.IsCompatible);
+        var violation = Assert.Single(report.Violations);
+        Assert.Equal(SeStringViolationKind.ControlCharMismatch, violation.Kind);
+        Assert.Contains("reordered", violation.Message, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PreservedControlBytes_MultisetAndOrder_Pass()
+    {
+        var text = "Hi <If><Raw><Run>a<RunEnd><Run#2>b<RunEnd#2><MacroEnd>";
+        var target = "Eo <If><Raw><Run>x<RunEnd><Run#2>y<RunEnd#2><MacroEnd>";
+
+        var report = SeStringCompatibilityValidator.Validate(text, target);
+        Assert.True(report.IsCompatible, report.Describe());
+    }
+
+    [Fact]
+    public void StandardGenderConditional_OnPayloadSource_IsAllowed()
+    {
+        var report = SeStringCompatibilityValidator.Validate(
+            "Welcome, <Num>",
+            "Hola, <Num> <Gender>Guerrera<GenderElse>Guerrero<GenderEnd>");
+
+        Assert.True(report.IsCompatible);
+    }
+
+    [Fact]
+    public void StandardGenderConditional_OnPayloadSource_StillChecksPayloadMultiset()
+    {
+        var report = SeStringCompatibilityValidator.Validate(
+            "Welcome, <Num>",
+            "Hola, <Gender>Guerrera<GenderElse>Guerrero<GenderEnd>");
+
+        Assert.False(report.IsCompatible);
+        Assert.Contains(report.Violations, v => v.Kind == SeStringViolationKind.MissingPayload);
+    }
+
+    [Fact]
+    public void StandardGenderConditional_OnPayloadSource_StillChecksPayloadOrder()
+    {
+        var report = SeStringCompatibilityValidator.Validate(
+            "<Num> then <Num#2>",
+            "<Num#2> luego <Num> <Gender>Guerrera<GenderElse>Guerrero<GenderEnd>");
+
+        Assert.False(report.IsCompatible);
+        Assert.Contains(report.Violations, v => v.Kind != SeStringViolationKind.InvalidStandardMacro);
+    }
+
+    [Fact]
+    public void StandardGenderConditional_OnPayloadSource_RejectsPayloadInsideBranch()
+    {
+        var report = SeStringCompatibilityValidator.Validate(
+            "Welcome, <Num>",
+            "Hola, <Gender><Num><GenderElse>Guerrero<GenderEnd>");
+
+        Assert.False(report.IsCompatible);
+        Assert.Equal(SeStringViolationKind.InvalidStandardMacro, Assert.Single(report.Violations).Kind);
+    }
+
+    [Fact]
+    public void TryTranslate_PayloadSource_AllowsGenderConditionalAlongsideSourcePayloads()
+    {
+        // Vanilla carries a real payload of its own (an If macro), like the Anogg letters whose
+        // source splits the player's name. The target keeps that payload AND adds a target-owned
+        // gender conditional, which the source never had.
+        var vanilla = SeStringTree.Serialize(
+        [
+            new SeNode.Literal("Dear "),
+            new SeNode.Macro(
+                0x08,
+                [
+                    new SeNode.RawByte(0xE9),
+                    new SeNode.Literal("\u0005"),
+                    new SeNode.Run([new SeNode.Literal("friend")], 0x01),
+                    new SeNode.Run([new SeNode.Literal("friend")], 0x01),
+                ],
+                0x01),
+            new SeNode.Literal(","),
+        ]);
+
+        var source = SeStringTreeTokenizer.TokenizeRawText(vanilla);
+        var payloadStart = source.IndexOf('<');
+        var payloadEnd = source.LastIndexOf('>') + 1;
+        var sourcePayload = source.Substring(payloadStart, payloadEnd - payloadStart);
+        var target = "<Gender>Querida<GenderElse>Querido<GenderEnd> " + sourcePayload + ":";
+
+        var translated = SeStringTree.TryTranslate(vanilla, source, target, out var result, out var reason);
+
+        Assert.True(translated, reason);
+
+        var rebuilt = SeStringTree.Parse(result);
+
+        // The target-owned conditional is emitted with the official French binary framing...
+        var gender = Assert.IsType<SeNode.Macro>(rebuilt[0]);
+        Assert.Equal(
+            "020815E905FF0851756572696461FF085175657269646F03",
+            Convert.ToHexString(SeStringTree.SerializeNode(gender)));
+
+        // ...and the source's own payload survives untouched.
+        var carried = Assert.IsType<SeNode.Macro>(rebuilt[2]);
+        Assert.Equal(0x08, carried.Code);
+        Assert.Equal("friend", Assert.IsType<SeNode.Literal>(Assert.IsType<SeNode.Run>(carried.Children[2]).Children[0]).Text);
+    }
+
+    [Fact]
+    public void TryTranslate_PayloadSource_RejectsGenderConditionalThatDropsASourcePayload()
+    {
+        var vanilla = SeStringTree.Serialize(
+        [
+            new SeNode.Literal("Dear "),
+            new SeNode.Macro(
+                0x08,
+                [
+                    new SeNode.RawByte(0xE9),
+                    new SeNode.Literal("\u0005"),
+                    new SeNode.Run([new SeNode.Literal("friend")], 0x01),
+                    new SeNode.Run([new SeNode.Literal("friend")], 0x01),
+                ],
+                0x01),
+        ]);
+
+        var source = SeStringTreeTokenizer.TokenizeRawText(vanilla);
+
+        // Dropping the source payload and keeping only the target-owned conditional is caught by
+        // the compatibility gate, which is where payload-loss is enforced for every target.
+        var report = SeStringCompatibilityValidator.Validate(
+            source,
+            "<Gender>Querida<GenderElse>Querido<GenderEnd>");
+
+        Assert.False(report.IsCompatible);
+        Assert.Contains(report.Violations, v => v.Kind == SeStringViolationKind.MissingPayload);
+    }
+}

--- a/vendor/XivSpanish.GameData/ExdPatcher.cs
+++ b/vendor/XivSpanish.GameData/ExdPatcher.cs
@@ -250,8 +250,6 @@ public static class ExdPatcher
                 ReadNulTerminatedBytes(stringArea, (int)strOffset));
         }
 
-        var fieldTargeted = new Dictionary<int, StringReplacement>();
-
         // Resolves the string-column ordinal a non-empty field-targeted replacement should write.
         // The label resolves to <paramref name="labeled"/>, but a corpus extracted before the
         // offset-correct field resolver can carry field labels PERMUTED relative to the on-disk
@@ -272,8 +270,7 @@ public static class ExdPatcher
             var found = -1;
             for (var ordinal = 0; ordinal < columnSource.Length; ordinal++)
             {
-                if (fieldTargeted.ContainsKey(ordinal)
-                    || !string.Equals(columnSource[ordinal], source, StringComparison.Ordinal))
+                if (!string.Equals(columnSource[ordinal], source, StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -289,13 +286,12 @@ public static class ExdPatcher
             return found >= 0 ? found : labeled;
         }
 
-        // Partition replacements:
-        //  - fieldTargeted[ordinal]: a replacement whose Field resolves to that exact column. It
-        //    is applied to ONLY that column (fixing the substring collision: a Singular source
-        //    that is a prefix of the Plural string can no longer hijack the Plural column).
-        //  - contentMatched: non-empty source, no usable field → legacy content matching across
-        //    the remaining (non-field-targeted) columns.
-        //  - emptyWrites: empty source, no usable field → legacy write-at-offset.
+        // Partition replacements. Keep the field-labelled candidates together first: a generated
+        // sheet may have two physical String columns swapped relative to its member declaration.
+        // A non-empty source identifies its real column exactly, while an explicitly empty source
+        // identifies the blank partner left behind by that swap (Snipe ActionText/VFXAdditional).
+        // Resolving the pair as a unit prevents the empty write from consuming ActionText's column.
+        var fieldCandidates = new List<(int LabeledOrdinal, StringReplacement Replacement)>();
         var contentMatched = new List<StringReplacement>();
         var emptyWrites = new Queue<StringReplacement>();
         foreach (var rep in rowReplacements)
@@ -303,15 +299,8 @@ public static class ExdPatcher
             if (rep.Field is not null && fieldToOrdinal.TryGetValue(rep.Field, out var ordinal)
                 && stringColumnOffsets[ordinal] + 4 <= fixedData.Length)
             {
-                // A non-empty source verifies/self-corrects its target column by exact content;
-                // an empty source (write-at-offset) keeps the literal label — an empty column has
-                // no content to match against, so retargeting it is undefined.
-                var target = rep.Source.Length == 0 ? ordinal : ResolveFieldOrdinal(ordinal, rep.Source);
-                if (!fieldTargeted.ContainsKey(target))
-                {
-                    fieldTargeted[target] = rep;
-                    continue;
-                }
+                fieldCandidates.Add((ordinal, rep));
+                continue;
             }
 
             if (rep.Source.Length == 0)
@@ -321,6 +310,65 @@ public static class ExdPatcher
             else
             {
                 contentMatched.Add(rep);
+            }
+        }
+
+        var fieldTargets = new int[fieldCandidates.Count];
+        for (var candidateIndex = 0; candidateIndex < fieldCandidates.Count; candidateIndex++)
+        {
+            var candidate = fieldCandidates[candidateIndex];
+            fieldTargets[candidateIndex] = candidate.Replacement.Source.Length == 0
+                ? candidate.LabeledOrdinal
+                : ResolveFieldOrdinal(candidate.LabeledOrdinal, candidate.Replacement.Source);
+        }
+
+        // An empty-source field normally keeps its literal label. If that label was claimed by a
+        // non-empty source which self-corrected from a different EMPTY labelled column, these two
+        // fields form a proven permutation: move the empty write to the vacated blank column.
+        // Do not guess beyond this exact pair; a source-less replacement alone has no evidence to
+        // choose among multiple empty columns.
+        for (var emptyIndex = 0; emptyIndex < fieldCandidates.Count; emptyIndex++)
+        {
+            var emptyCandidate = fieldCandidates[emptyIndex];
+            if (emptyCandidate.Replacement.Source.Length != 0)
+            {
+                continue;
+            }
+
+            for (var sourceIndex = 0; sourceIndex < fieldCandidates.Count; sourceIndex++)
+            {
+                var sourceCandidate = fieldCandidates[sourceIndex];
+                if (sourceCandidate.Replacement.Source.Length == 0
+                    || fieldTargets[sourceIndex] != emptyCandidate.LabeledOrdinal
+                    || sourceCandidate.LabeledOrdinal == emptyCandidate.LabeledOrdinal
+                    || !string.Equals(columnSource[sourceCandidate.LabeledOrdinal], string.Empty, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                fieldTargets[emptyIndex] = sourceCandidate.LabeledOrdinal;
+                break;
+            }
+        }
+
+        var fieldTargeted = new Dictionary<int, StringReplacement>();
+        for (var candidateIndex = 0; candidateIndex < fieldCandidates.Count; candidateIndex++)
+        {
+            var replacement = fieldCandidates[candidateIndex].Replacement;
+            if (fieldTargeted.TryAdd(fieldTargets[candidateIndex], replacement))
+            {
+                continue;
+            }
+
+            // Preserve the legacy fallback for two manifest rows that genuinely target the same
+            // column. The first field-targeted replacement remains authoritative.
+            if (replacement.Source.Length == 0)
+            {
+                emptyWrites.Enqueue(replacement);
+            }
+            else
+            {
+                contentMatched.Add(replacement);
             }
         }
 

--- a/vendor/XivSpanish.GameData/SeStringCompatibilityValidator.cs
+++ b/vendor/XivSpanish.GameData/SeStringCompatibilityValidator.cs
@@ -146,11 +146,30 @@ public static partial class SeStringCompatibilityValidator
         var violations = new List<SeStringViolation>();
         if (HasPayloads(source))
         {
-            violations.Add(new SeStringViolation(
-                SeStringViolationKind.InvalidStandardMacro,
-                GenderToken(target),
-                target.IndexOf(SeStringStandardMacros.GenderOpen, StringComparison.Ordinal),
-                "standard target macros may only be added when the source SeString is plain text"));
+            // Mixed target: a gender conditional added on top of the source's own payloads. The
+            // conditional itself is target-owned, so it is stripped before the payload multiset,
+            // order, nesting and control bytes are checked exactly as for any other target.
+            if (!SeStringStandardMacros.TrySplitGenderMacros(target, out var stripped, out var macros, out var splitReason)
+                || macros.Count == 0)
+            {
+                violations.Add(new SeStringViolation(
+                    SeStringViolationKind.InvalidStandardMacro,
+                    GenderToken(target),
+                    target.IndexOf(SeStringStandardMacros.GenderOpen, StringComparison.Ordinal),
+                    splitReason ?? "invalid standard target macro"));
+                return new SeStringCompatibilityReport(violations);
+            }
+
+            var withoutMacros = StripMarkers(stripped);
+            var sourceAtoms = ExtractAtoms(source);
+            var targetAtoms = ExtractAtoms(withoutMacros);
+
+            CheckStrayDelimiters(withoutMacros, targetAtoms, violations);
+            CheckMultiset(sourceAtoms, targetAtoms, violations);
+            CheckRunNesting(targetAtoms, violations);
+            CheckOrder(sourceAtoms, targetAtoms, violations);
+            CheckControlChars(source, withoutMacros, violations);
+            CheckStaleRunLength(source, withoutMacros, sourceAtoms, targetAtoms, violations);
             return new SeStringCompatibilityReport(violations);
         }
 
@@ -166,6 +185,30 @@ public static partial class SeStringCompatibilityValidator
 
         CheckControlChars(source, target, violations);
         return new SeStringCompatibilityReport(violations);
+    }
+
+    private static string StripMarkers(string text)
+    {
+        var builder = new System.Text.StringBuilder(text.Length);
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] != '\uFFF9')
+            {
+                builder.Append(text[i]);
+                continue;
+            }
+
+            var close = text.IndexOf('\uFFFA', i);
+            if (close < 0)
+            {
+                builder.Append(text[i]);
+                continue;
+            }
+
+            i = close;
+        }
+
+        return builder.ToString();
     }
 
     private static string? GenderToken(string target)
@@ -407,10 +450,16 @@ public static partial class SeStringCompatibilityValidator
     }
 
     // Non-whitespace C0 control characters in the tokenized text are raw macro expression bytes
-    // (e.g. the \x03 branch separators inside an <If> body). They are machinery, not text: the
-    // target must carry exactly the same sequence. Whitespace controls (\t \n \r) are ordinary
-    // text a translator may legitimately reflow, so they are excluded — the same definition as
+    // (e.g. the \x03 branch separators inside an <If> body, \x05 parameter bytes, \x0c/\x12
+    // expression bytes). They are machinery, not text: the target must carry exactly the same
+    // sequence. Whitespace controls (\t \n \r) are ordinary text a translator may legitimately
+    // reflow, so they are excluded — the same definition as
     // SeStringTokenizer.FindUnsafeControlReferences.
+    //
+    // The MULTISET is compared first so the diagnostic names exactly which raw bytes the target
+    // lost or invented (the custom-doma-001 incident: 6 hand-written rows silently dropped
+    // \x0c/\x05/\x12). Only when the multiset matches but the order differs does the message fall
+    // back to the full sequence dump.
     private static void CheckControlChars(string source, string target, List<SeStringViolation> violations)
     {
         var sourceControls = ControlChars(source);
@@ -420,11 +469,62 @@ public static partial class SeStringCompatibilityValidator
             return;
         }
 
+        var missing = MultisetDifference(sourceControls, targetControls);
+        var extra = MultisetDifference(targetControls, sourceControls);
+        if (missing.Count > 0 || extra.Count > 0)
+        {
+            var parts = new List<string>(2);
+            if (missing.Count > 0)
+            {
+                parts.Add($"lost from target: [{FormatControls(missing)}]");
+            }
+
+            if (extra.Count > 0)
+            {
+                parts.Add($"invented in target: [{FormatControls(extra)}]");
+            }
+
+            violations.Add(new SeStringViolation(
+                SeStringViolationKind.ControlCharMismatch,
+                null,
+                -1,
+                $"raw control byte multiset differs — {string.Join("; ", parts)} "
+                + $"(source has [{FormatControls(sourceControls)}], target has [{FormatControls(targetControls)}])"));
+            return;
+        }
+
         violations.Add(new SeStringViolation(
             SeStringViolationKind.ControlCharMismatch,
             null,
             -1,
-            $"raw control bytes differ: source has [{FormatControls(sourceControls)}], target has [{FormatControls(targetControls)}]"));
+            $"raw control bytes are reordered: source has [{FormatControls(sourceControls)}], "
+            + $"target has [{FormatControls(targetControls)}]"));
+    }
+
+    // Multiset difference left \ right: every occurrence of a control char in <paramref name="left"/>
+    // beyond its count in <paramref name="right"/>, in first-seen order.
+    private static List<char> MultisetDifference(List<char> left, List<char> right)
+    {
+        var counts = new Dictionary<char, int>();
+        foreach (var c in right)
+        {
+            counts[c] = counts.GetValueOrDefault(c) + 1;
+        }
+
+        var difference = new List<char>();
+        foreach (var c in left)
+        {
+            if (counts.GetValueOrDefault(c) > 0)
+            {
+                counts[c]--;
+            }
+            else
+            {
+                difference.Add(c);
+            }
+        }
+
+        return difference;
     }
 
     /// <summary>Base-name prefix of legacy opaque 0xFF run tokens whose mapped bytes embed the run-length prefix verbatim.</summary>

--- a/vendor/XivSpanish.GameData/SeStringStandardMacros.cs
+++ b/vendor/XivSpanish.GameData/SeStringStandardMacros.cs
@@ -17,6 +17,11 @@ public static class SeStringStandardMacros
     private const byte GlobalNumberExpression = 0xE9;
     private const char PlayerGenderParameter = '\x05'; // packed integer 4: player gender
 
+    // Private markers used to carry a gender conditional through the payload detokenizer. Chosen
+    // from the "interlinear annotation" block: never present in game text nor in a target.
+    private const char MarkerOpen = '\uFFF9';
+    private const char MarkerClose = '\uFFFA';
+
     /// <summary>True when text contains any reserved standard-macro delimiter.</summary>
     public static bool HasReservedDelimiter(string text)
         => FindUnescaped(text, GenderOpen, 0) >= 0
@@ -96,15 +101,7 @@ public static class SeStringStandardMacros
                 return false;
             }
 
-            nodes.Add(new SeNode.Macro(
-                IfMacroCode,
-                [
-                    new SeNode.RawByte(GlobalNumberExpression),
-                    new SeNode.Literal(PlayerGenderParameter.ToString()),
-                    new SeNode.Run([new SeNode.Literal(female)], 0x01),
-                    new SeNode.Run([new SeNode.Literal(male)], 0x01),
-                ],
-                0x01));
+            nodes.Add(BuildGenderMacro(female, male));
 
             position = endPosition + GenderEnd.Length;
         }
@@ -112,6 +109,219 @@ public static class SeStringStandardMacros
         FlushLiteral(nodes, literal);
         return true;
     }
+
+    /// <summary>
+    /// Splits the gender constructs out of <paramref name="text"/>, replacing each with a private
+    /// marker, and returns the synthesized <c>If</c> nodes in the order they appeared. Lets a
+    /// target carry BOTH the source's real payloads and a target-authored gender conditional: the
+    /// caller detokenizes the marked text against the source token map and then splices the nodes
+    /// back in with <see cref="SpliceMarkers"/>. Branches must still be literal text.
+    /// </summary>
+    public static bool TrySplitGenderMacros(
+        string text,
+        out string markedText,
+        out List<SeNode> macros,
+        out string? reason)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        markedText = text;
+        macros = [];
+        reason = null;
+
+        if (text.Contains(MarkerOpen) || text.Contains(MarkerClose))
+        {
+            reason = "target contains a reserved gender-macro marker character";
+            return false;
+        }
+
+        var builder = new StringBuilder();
+        var position = 0;
+        while (position < text.Length)
+        {
+            var open = FindUnescaped(text, GenderOpen, position);
+            if (open < 0)
+            {
+                builder.Append(text, position, text.Length - position);
+                break;
+            }
+
+            builder.Append(text, position, open - position);
+
+            var femaleStart = open + GenderOpen.Length;
+            var elsePosition = FindUnescaped(text, GenderElse, femaleStart);
+            var nestedPosition = FindUnescaped(text, GenderOpen, femaleStart);
+            if (elsePosition < 0 || (nestedPosition >= 0 && nestedPosition < elsePosition))
+            {
+                reason = $"{GenderOpen} at index {open} has no valid {GenderElse}";
+                macros = [];
+                return false;
+            }
+
+            var maleStart = elsePosition + GenderElse.Length;
+            var endPosition = FindUnescaped(text, GenderEnd, maleStart);
+            nestedPosition = FindUnescaped(text, GenderOpen, maleStart);
+            if (endPosition < 0 || (nestedPosition >= 0 && nestedPosition < endPosition))
+            {
+                reason = $"{GenderOpen} at index {open} has no valid {GenderEnd}";
+                macros = [];
+                return false;
+            }
+
+            if (!TryDecodeLiteralBranch(text[femaleStart..elsePosition], out var female, out reason)
+                || !TryDecodeLiteralBranch(text[maleStart..endPosition], out var male, out reason))
+            {
+                macros = [];
+                return false;
+            }
+
+            if (female.Length == 0 || male.Length == 0)
+            {
+                reason = "gender conditional requires non-empty female and male branches";
+                macros = [];
+                return false;
+            }
+
+            builder.Append(MarkerOpen).Append(macros.Count).Append(MarkerClose);
+            macros.Add(BuildGenderMacro(female, male));
+            position = endPosition + GenderEnd.Length;
+        }
+
+        markedText = builder.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Replaces the markers left by <see cref="TrySplitGenderMacros"/> with their macro nodes,
+    /// walking runs and macros so a conditional may sit at any depth of the rebuilt tree.
+    /// </summary>
+    public static bool SpliceMarkers(List<SeNode> nodes, IReadOnlyList<SeNode> macros, out string? reason)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+        ArgumentNullException.ThrowIfNull(macros);
+        reason = null;
+
+        var spliced = 0;
+        if (!SpliceInto(nodes, macros, ref spliced, out reason))
+        {
+            return false;
+        }
+
+        if (spliced != macros.Count)
+        {
+            reason = "gender conditional markers were lost while rebuilding the target";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool SpliceInto(List<SeNode> nodes, IReadOnlyList<SeNode> macros, ref int spliced, out string? reason)
+    {
+        reason = null;
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            switch (nodes[i])
+            {
+                case SeNode.Literal literal when literal.Text.Contains(MarkerOpen):
+                {
+                    if (!TryExpandLiteral(literal.Text, macros, ref spliced, out var expanded, out reason))
+                    {
+                        return false;
+                    }
+
+                    nodes.RemoveAt(i);
+                    nodes.InsertRange(i, expanded);
+                    i += expanded.Count - 1;
+                    break;
+                }
+
+                case SeNode.Run run:
+                {
+                    var children = new List<SeNode>(run.Children);
+                    if (!SpliceInto(children, macros, ref spliced, out reason))
+                    {
+                        return false;
+                    }
+
+                    nodes[i] = new SeNode.Run(children, run.MarkerByte);
+                    break;
+                }
+
+                case SeNode.Macro macro:
+                {
+                    var children = new List<SeNode>(macro.Children);
+                    if (!SpliceInto(children, macros, ref spliced, out reason))
+                    {
+                        return false;
+                    }
+
+                    nodes[i] = new SeNode.Macro(macro.Code, children, macro.LengthMarker);
+                    break;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryExpandLiteral(
+        string text,
+        IReadOnlyList<SeNode> macros,
+        ref int spliced,
+        out List<SeNode> expanded,
+        out string? reason)
+    {
+        expanded = [];
+        reason = null;
+
+        var literal = new StringBuilder();
+        var position = 0;
+        while (position < text.Length)
+        {
+            if (text[position] != MarkerOpen)
+            {
+                literal.Append(text[position++]);
+                continue;
+            }
+
+            var close = text.IndexOf(MarkerClose, position);
+            if (close < 0 || !int.TryParse(text.AsSpan(position + 1, close - position - 1), out var index)
+                || index < 0 || index >= macros.Count)
+            {
+                reason = "malformed gender conditional marker in the rebuilt target";
+                expanded = [];
+                return false;
+            }
+
+            if (literal.Length > 0)
+            {
+                expanded.Add(new SeNode.Literal(literal.ToString()));
+                literal.Clear();
+            }
+
+            expanded.Add(macros[index]);
+            spliced++;
+            position = close + 1;
+        }
+
+        if (literal.Length > 0)
+        {
+            expanded.Add(new SeNode.Literal(literal.ToString()));
+        }
+
+        return true;
+    }
+
+    private static SeNode BuildGenderMacro(string female, string male)
+        => new SeNode.Macro(
+            IfMacroCode,
+            [
+                new SeNode.RawByte(GlobalNumberExpression),
+                new SeNode.Literal(PlayerGenderParameter.ToString()),
+                new SeNode.Run([new SeNode.Literal(female)], 0x01),
+                new SeNode.Run([new SeNode.Literal(male)], 0x01),
+            ],
+            0x01);
 
     private static void FlushLiteral(List<SeNode> nodes, StringBuilder literal)
     {

--- a/vendor/XivSpanish.GameData/SeStringTree.cs
+++ b/vendor/XivSpanish.GameData/SeStringTree.cs
@@ -100,16 +100,37 @@ public static class SeStringTree
         string? detokenReason;
         if (SeStringStandardMacros.HasReservedDelimiter(target))
         {
-            if (tok.Tokens.Count != 0)
+            if (tok.Tokens.Count == 0)
             {
-                reason = "standard target macros may only be added when the source SeString is plain text";
-                return false;
+                if (!SeStringStandardMacros.TryParse(target, out rebuilt, out detokenReason))
+                {
+                    reason = detokenReason ?? "could not parse standard target macros";
+                    return false;
+                }
             }
-
-            if (!SeStringStandardMacros.TryParse(target, out rebuilt, out detokenReason))
+            else
             {
-                reason = detokenReason ?? "could not parse standard target macros";
-                return false;
+                // Mixed target: the source carries real payloads AND the target adds a gender
+                // conditional. Carry the conditional through the payload detokenizer as a marker,
+                // then splice the synthesized If node back in, so the source's payload multiset and
+                // run nesting are validated exactly as in the normal path.
+                if (!SeStringStandardMacros.TrySplitGenderMacros(target, out var markedTarget, out var macros, out detokenReason))
+                {
+                    reason = detokenReason ?? "could not parse standard target macros";
+                    return false;
+                }
+
+                if (!SeStringTreeTokenizer.TryDetokenize(markedTarget, tok.Tokens, out rebuilt, out detokenReason))
+                {
+                    reason = detokenReason ?? "could not detokenize target";
+                    return false;
+                }
+
+                if (!SeStringStandardMacros.SpliceMarkers(rebuilt, macros, out detokenReason))
+                {
+                    reason = detokenReason ?? "could not place standard target macros";
+                    return false;
+                }
             }
         }
         else if (!SeStringTreeTokenizer.TryDetokenize(target, tok.Tokens, out rebuilt, out detokenReason))


### PR DESCRIPTION
## v0.4.3

Versión centrada en la **calidad** de lo ya traducido más que en volumen nuevo: una campaña de revisión trilingüe (EN + FR → ES) sobre el guion existente y corrección de errores (gracias a quienes reportaron fallos)

- **Misiones de job de *Stormblood***: traducidas las líneas completas de **samurái**  (`quest-jobsam-001`, **889 filas**) y **mago rojo** (`quest-jobrdm-001`, **1.134 filas**)
- **Campaña exhaustiva de revisión de calidad**: Muchos cambios para enumerarlos.. pero resumiendo:
  > Se acaba con la formulacion de "alma aventurera" y similares
  > Revisión de flexión de género del personaje
  > Correcciones varias
- **Herramientas**: el validador de SeString acepta una condicional de género propia de la traducción junto a los payloads del original, y añade diagnóstico por multiconjunto de bytes de control; el detector de fugas de inglés de `BatchVerify` acota su lista de excepciones por hoja.
